### PR TITLE
Added support for error codes

### DIFF
--- a/src/Valit/Errors/ValitRuleError.cs
+++ b/src/Valit/Errors/ValitRuleError.cs
@@ -1,0 +1,24 @@
+namespace Valit
+{
+    internal class ValitRuleError
+    {
+        public string Message  { get; private set; }
+        public int? ErrorCode { get; private set; }
+
+        private ValitRuleError(string message)
+        {
+            Message = message;
+        }
+
+        private ValitRuleError(int errorCode)
+        {
+            ErrorCode = errorCode;
+        }
+
+        public static ValitRuleError CreateForMessage(string message)
+            => new ValitRuleError(message);
+
+        public static ValitRuleError CreateForErrorCode(int errorCode)
+            => new ValitRuleError(errorCode);   
+    }
+}

--- a/src/Valit/Result/IValitResult.cs
+++ b/src/Valit/Result/IValitResult.cs
@@ -4,6 +4,8 @@ namespace Valit
     {
          bool Succeeded { get; }
 
-         string[] Errors { get; }
+         string[] ErrorMessages { get; }
+
+         int[] ErrorCodes { get; }
     }
 }

--- a/src/Valit/Result/ValitResult.cs
+++ b/src/Valit/Result/ValitResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Valit
 {
@@ -6,32 +7,53 @@ namespace Valit
     {
         public bool Succeeded { get; private set; }
 
-        public string[] Errors { get; private set; }
+        public string[] ErrorMessages { get; private set; }
+
+        public int[] ErrorCodes { get; private set; }
 
         private ValitResult()
         {
             Succeeded = true;
-            Errors = Enumerable.Empty<string>().ToArray();
+            ErrorMessages = Enumerable.Empty<string>().ToArray();
+            ErrorCodes = Enumerable.Empty<int>().ToArray();
         }
 
-        private ValitResult(string[] errors)
+        private ValitResult(IEnumerable<ValitRuleError> errors)
         {
             Succeeded = false;
-            Errors = errors;
+
+            ErrorMessages = errors
+                .Where(e => e.Message != null)
+                .Select(e => e.Message)
+                .ToArray();
+
+            ErrorCodes = errors
+                .Where(e => e.ErrorCode.HasValue)
+                .Select(e => e.ErrorCode.Value)
+                .ToArray();
+        }
+
+        private ValitResult(string[] errorMessages, int[] errorCodes)
+        {
+            ErrorMessages = errorMessages;
+            ErrorCodes = errorCodes;
         }
 
         internal static ValitResult CreateSucceeded()
             => new ValitResult();
 
-        internal static ValitResult CreateFailed(string[] errors)
-            => new ValitResult( errors);
+        internal static ValitResult CreateFailed(IEnumerable<ValitRuleError> errors)
+            => new ValitResult(errors);
 
+        internal static ValitResult CreateFailed(string[] errorMessages, int[] errorCodes)
+            => new ValitResult(errorMessages, errorCodes);
 
         public static ValitResult operator &(ValitResult result1, IValitResult result2)
         {
             var succeed = result1.Succeeded && result2.Succeeded;
-            var errors = result1.Errors.Concat(result2.Errors).ToArray();
-            return succeed? ValitResult.CreateSucceeded() : ValitResult.CreateFailed(errors);
+            var errorMessages = result1.ErrorMessages.Concat(result2.ErrorMessages).ToArray();
+            var errorCodes = result1.ErrorCodes.Concat(result2.ErrorCodes).ToArray();
+            return succeed? ValitResult.CreateSucceeded() : ValitResult.CreateFailed(errorMessages, errorCodes);
         }
     }
 }

--- a/src/Valit/Rules/Extensions/ValitRuleExtensions.cs
+++ b/src/Valit/Rules/Extensions/ValitRuleExtensions.cs
@@ -136,7 +136,20 @@ namespace Valit
             var accessor = rule.GetAccessor();
             var previousRuleAccessor = accessor.PreviousRule.GetAccessor();
 
-            previousRuleAccessor.AddErrorMessage(message);
+            var error = ValitRuleError.CreateForMessage(message);
+            previousRuleAccessor.AddError(error);
+            return new ValitRule<TObject, TProperty>(accessor.PreviousRule);
+        }    
+
+        public static IValitRule<TObject, TProperty> WithErrorCode<TObject, TProperty>(this IValitRule<TObject, TProperty> rule, int errorCode) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            
+            var accessor = rule.GetAccessor();
+            var previousRuleAccessor = accessor.PreviousRule.GetAccessor();
+
+            var error = ValitRuleError.CreateForErrorCode(errorCode);
+            previousRuleAccessor.AddError(error);
             return new ValitRule<TObject, TProperty>(accessor.PreviousRule);
         }           
 

--- a/src/Valit/Rules/IValitRuleAccessor.cs
+++ b/src/Valit/Rules/IValitRuleAccessor.cs
@@ -6,7 +6,7 @@ namespace Valit
 {
     internal interface IValitRuleAccessor
     {
-        void AddErrorMessage(string message);
+        void AddError(ValitRuleError error);
         void AddCondition(Func<bool> predicate);
         void AddTags(params string[] tags);
     }

--- a/src/Valit/Rules/ValitRule.cs
+++ b/src/Valit/Rules/ValitRule.cs
@@ -18,7 +18,7 @@ namespace Valit
         private Predicate<TProperty> _predicate;
         private readonly List<Func<bool>> _conditions;
         private readonly IValitRule<TObject, TProperty> _previousRule;
-		private readonly List<string> _errorMessages;
+		private readonly List<ValitRuleError> _errors;
         private readonly ValitRulesStrategies _strategy;
         private readonly List<string> _tags;
 
@@ -38,7 +38,7 @@ namespace Valit
 
         private ValitRule()
         {            
-            _errorMessages = new List<string>();
+            _errors = new List<ValitRuleError>();
             _conditions = new List<Func<bool>>();
             _tags = new List<string>();
         }		
@@ -48,9 +48,9 @@ namespace Valit
 			_predicate = predicate;
 		}
 
-		void IValitRuleAccessor.AddErrorMessage(string message)
+		void IValitRuleAccessor.AddError(ValitRuleError error)
 		{
-			_errorMessages.Add(message);
+			_errors.Add(error);
 		}
 
 		void IValitRuleAccessor.AddCondition(Func<bool> predicate)
@@ -73,7 +73,7 @@ namespace Valit
 
             var isSatisfied = (_predicate == null) ? true : _predicate(property);
 
-            return hasAllConditionsFulfilled && !isSatisfied? ValitResult.CreateFailed(_errorMessages.ToArray()) : ValitResult.CreateSucceeded();		
+            return hasAllConditionsFulfilled && !isSatisfied? ValitResult.CreateFailed(_errors) : ValitResult.CreateSucceeded();		
         }
 	}
 }

--- a/tests/Valit.Tests/ExtensionsTests/framework_tests.cs
+++ b/tests/Valit.Tests/ExtensionsTests/framework_tests.cs
@@ -29,7 +29,7 @@ namespace Valit.Tests.ExtensionsTests
                 .Validate();
 
             Assert.Equal(true, result.Succeeded);
-            Assert.Equal("", string.Join(", ", result.Errors ?? new string[1]));
+            Assert.Equal("", string.Join(", ", result.ErrorMessages ?? new string[1]));
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace Valit.Tests.ExtensionsTests
 
             Assert.Equal(false, result1.Succeeded);
             Assert.Equal("Should add message 1", 
-                string.Join(", ", result1.Errors ?? new string[1]));
+                string.Join(", ", result1.ErrorMessages ?? new string[1]));
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Valit.Tests.ExtensionsTests
 
             Assert.Equal(false, result.Succeeded);
             Assert.Equal("Should add message 2", 
-                string.Join(", ", result.Errors ?? new string[1]));
+                string.Join(", ", result.ErrorMessages ?? new string[1]));
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace Valit.Tests.ExtensionsTests
 
             Assert.Equal(false, result.Succeeded);
             Assert.Equal("Should add message 1, Should add message 2", 
-                string.Join(", ", result.Errors ?? new string[1]));
+                string.Join(", ", result.ErrorMessages ?? new string[1]));
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Valit.Tests.ExtensionsTests
 
             Assert.Equal(false, result.Succeeded);
             Assert.Equal("Should add message 3", 
-                string.Join(", ", result.Errors ?? new string[1]));
+                string.Join(", ", result.ErrorMessages ?? new string[1]));
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace Valit.Tests.ExtensionsTests
 
             Assert.Equal(false, result.Succeeded);
             Assert.Equal("Should add message 1, Should add message 3", 
-                string.Join(", ", result.Errors ?? new string[1]));
+                string.Join(", ", result.ErrorMessages ?? new string[1]));
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace Valit.Tests.ExtensionsTests
 
             Assert.Equal(false, result.Succeeded);
             Assert.Equal("Should add message 2, Should add message 3", 
-                string.Join(", ", result.Errors ?? new string[1]));
+                string.Join(", ", result.ErrorMessages ?? new string[1]));
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace Valit.Tests.ExtensionsTests
 
             Assert.Equal(false, result.Succeeded);
             Assert.Equal("Should add message 1, Should add message 2, Should add message 3", 
-                string.Join(", ", result.Errors ?? new string[1]));
+                string.Join(", ", result.ErrorMessages ?? new string[1]));
         }
 
         [Fact]

--- a/tests/Valit.Tests/TypeTests/byte_tests.cs
+++ b/tests/Valit.Tests/TypeTests/byte_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/decimal_tests.cs
+++ b/tests/Valit.Tests/TypeTests/decimal_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/double_tests.cs
+++ b/tests/Valit.Tests/TypeTests/double_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/int16_tests.cs
+++ b/tests/Valit.Tests/TypeTests/int16_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/int32_tests.cs
+++ b/tests/Valit.Tests/TypeTests/int32_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/int64_tests.cs
+++ b/tests/Valit.Tests/TypeTests/int64_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/single_tests.cs
+++ b/tests/Valit.Tests/TypeTests/single_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/uint16_tests.cs
+++ b/tests/Valit.Tests/TypeTests/uint16_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/uint32_tests.cs
+++ b/tests/Valit.Tests/TypeTests/uint32_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
         }
     }
 }

--- a/tests/Valit.Tests/TypeTests/uint64_tests.cs
+++ b/tests/Valit.Tests/TypeTests/uint64_tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.TypeTests
                 .Validate();
 
             Assert.False(result.Succeeded);
-            Assert.Equal(2, result.Errors.Length);
+            Assert.Equal(2, result.ErrorMessages.Length);
             Assert.True(true);
         }
     }


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. 6 ( #6 ) 

Yep, so I decided to go for ValitRuleError I'd love to your opinion about that one. If it's fine, I'll write some unit tests for that, so please don't merge this yet!

# Changes
- added `ValitRuleError` class
- chnged collection inside ValitRule to `List<ValitRuleError>`
- changed ValitResult so it keep collection of messages and error codes
- added `WithErrorCode()` extension method 