### PR TITLE
Added support dor DateTime, DateTimeOffset and TimeSpan

### DIFF
--- a/src/Valit/Rules/Extensions/ValitRuleDateTimeExtensions.cs
+++ b/src/Valit/Rules/Extensions/ValitRuleDateTimeExtensions.cs
@@ -1,0 +1,229 @@
+using System;
+
+namespace Valit
+{
+    public static class ValitRuleDateTimeExtensions
+    {
+        public static IValitRule<TObject, DateTime> IsAfter<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p > datetime);
+        }
+
+        public static IValitRule<TObject, DateTime> IsAfter<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => datetime.HasValue && p > datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsAfter<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value > datetime);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsAfter<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value > datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime> IsBefore<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p < datetime);
+        }
+
+        public static IValitRule<TObject, DateTime> IsBefore<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => datetime.HasValue && p < datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsBefore<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value < datetime);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsBefore<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value < datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p >= datetime);
+        }
+
+        public static IValitRule<TObject, DateTime> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => datetime.HasValue && p >= datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value >= datetime);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value >= datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p <= datetime);
+        }
+
+        public static IValitRule<TObject, DateTime> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => datetime.HasValue && p <= datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value <= datetime);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value <= datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime> IsAfterNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p > DateTime.Now);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsAfterNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value > DateTime.Now);
+        }
+
+        public static IValitRule<TObject, DateTime> IsBeforeNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p < DateTime.Now);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsBeforeNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value < DateTime.Now);
+        }
+
+        public static IValitRule<TObject, DateTime> IsAfterUtcNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p > DateTime.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsAfterUtcNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value > DateTime.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTime> IsBeforeUtcNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p < DateTime.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsBeforeUtcNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value < DateTime.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTime> IsAfterOrEqualToNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p >= DateTime.Now);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsAfterOrEqualToNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value >= DateTime.Now);
+        }
+
+        public static IValitRule<TObject, DateTime> IsBeforeOrEqualToNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p <= DateTime.Now);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsBeforeOrEqualToNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value <= DateTime.Now);
+        }
+
+        public static IValitRule<TObject, DateTime> IsAfterOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p >= DateTime.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsAfterOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value >= DateTime.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTime> IsBeforeOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p <= DateTime.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsBeforeOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value <= DateTime.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTime> IsEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p == datetime);
+        }
+
+        public static IValitRule<TObject, DateTime> IsEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => datetime.HasValue && p == datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value == datetime);
+        }
+
+        public static IValitRule<TObject, DateTime?> IsEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value == datetime.Value);
+        }
+
+        public static IValitRule<TObject, DateTime?> Required<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue);
+        }
+    }
+}

--- a/src/Valit/Rules/Extensions/ValitRuleDateTimeOffsetExtensions.cs
+++ b/src/Valit/Rules/Extensions/ValitRuleDateTimeOffsetExtensions.cs
@@ -1,0 +1,229 @@
+using System;
+
+namespace Valit
+{
+    public static class ValitRuleDateTimeOffsetOffsetExtensions
+    {
+        public static IValitRule<TObject, DateTimeOffset> IsAfter<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p > dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsAfter<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => dateTimeOffset.HasValue && p > dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsAfter<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value > dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsAfter<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value > dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsBefore<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p < dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsBefore<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => dateTimeOffset.HasValue && p < dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsBefore<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value < dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsBefore<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value < dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p >= dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => dateTimeOffset.HasValue && p >= dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value >= dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value >= dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p <= dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => dateTimeOffset.HasValue && p <= dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value <= dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value <= dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsAfterNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p > DateTimeOffset.Now);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsAfterNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value > DateTimeOffset.Now);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsBeforeNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p < DateTimeOffset.Now);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsBeforeNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value < DateTimeOffset.Now);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsAfterUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p > DateTimeOffset.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsAfterUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value > DateTimeOffset.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsBeforeUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p < DateTimeOffset.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsBeforeUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value < DateTimeOffset.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsAfterOrEqualToNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p >= DateTimeOffset.Now);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrEqualToNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value >= DateTimeOffset.Now);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrEqualToNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p <= DateTimeOffset.Now);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrEqualToNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value <= DateTimeOffset.Now);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsAfterOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p >= DateTimeOffset.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value >= DateTimeOffset.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p <= DateTimeOffset.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value <= DateTimeOffset.UtcNow);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p == dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset> IsEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => dateTimeOffset.HasValue && p == dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value == dateTimeOffset);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> IsEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value == dateTimeOffset.Value);
+        }
+
+        public static IValitRule<TObject, DateTimeOffset?> Required<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue);
+        }
+    }
+}

--- a/src/Valit/Rules/Extensions/ValitRuleDoubleExtensions.cs
+++ b/src/Valit/Rules/Extensions/ValitRuleDoubleExtensions.cs
@@ -4,7 +4,7 @@ namespace Valit
 {
     public static class ValitRuleDoubleExtensions
     {
-        public static IValitRule<TObject, double> IsGreaterThan<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
+        public static IValitRule<TObject, double> IsGreaterThan<TObject>(this IValitRule<TObject, double> rule, double value, double epislon = 0.0d) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p > value);

--- a/src/Valit/Rules/Extensions/ValitRuleTimeSpanExtensions.cs
+++ b/src/Valit/Rules/Extensions/ValitRuleTimeSpanExtensions.cs
@@ -1,0 +1,145 @@
+using System;
+
+namespace Valit
+{
+    public static class ValitRuleTimeSpanExtensions
+    {
+        public static IValitRule<TObject, TimeSpan> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p > TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => TimeSpan.HasValue && p > TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value > TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value > TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p < TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => TimeSpan.HasValue && p < TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value < TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value < TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p >= TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => TimeSpan.HasValue && p >= TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value >= TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value >= TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p <= TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => TimeSpan.HasValue && p <= TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value <= TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value <= TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p == TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => TimeSpan.HasValue && p == TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value == TimeSpan);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value == TimeSpan.Value);
+        }
+
+        public static IValitRule<TObject, TimeSpan> IsNonZero<TObject>(this IValitRule<TObject, TimeSpan> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);    
+            return rule.Satisfies(p => p != TimeSpan.Zero);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> IsNonZero<TObject>(this IValitRule<TObject, TimeSpan?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue && p.Value != TimeSpan.Zero);
+        }
+
+        public static IValitRule<TObject, TimeSpan?> Required<TObject>(this IValitRule<TObject, TimeSpan?> rule) where TObject : class
+        {
+            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
+            return rule.Satisfies(p => p.HasValue);
+        }
+    }
+}

--- a/src/Valit/Rules/Extensions/ValitRuleUInt16Extensions.cs
+++ b/src/Valit/Rules/Extensions/ValitRuleUInt16Extensions.cs
@@ -131,7 +131,6 @@ namespace Valit
             return rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
         }
 
-
         public static IValitRule<TObject, ushort> IsNonZero<TObject>(this IValitRule<TObject, ushort> rule) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);    


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. 46 ( #46 ) 

# Changes
For DateTime and DateTimeOffset types I added:
- IsAfter
- IsBefore
- IsAfterOrEqualTo
- IsBeforeOrEqualTo
- IsAfterNow
- IsBeforeNow
- IsAfterUtcNow
- IsBeforeUtcNow
- IsAfterOrEqualToNow
- IsBeforeOrEqualToNow
- IsAfterOrEqualToUtcNow
- IsBeforeOrEqualToUtcNow
- IsEqualTo
- Required

For TimeSpan type I added:
- IsLessThan
- IsGreaterThan
- IsLessThanOrEqalTo
- IsGreaterThanOrEqualTo
- IsEqualTo
- IsNonZero
- Required

All type extensions support Nullable<T>.