### PR TITLE
Added unit tests for IEnumerable<T>, fixed NullReferenceException whe…

### DIFF
--- a/src/Valit/Extensions/TypeExtensions.cs
+++ b/src/Valit/Extensions/TypeExtensions.cs
@@ -26,18 +26,5 @@ namespace Valit
             return NumericTypes.Contains(type) ||
                    NumericTypes.Contains(Nullable.GetUnderlyingType(type));
         }
-
-        internal static int Count(this IEnumerable enumerable)
-        {
-            var enumerator = enumerable.GetEnumerator();
-            var itemsNumber = 0;
-
-            while(enumerator.MoveNext())
-            {
-                itemsNumber ++;
-            }
-
-            return itemsNumber;
-        }
     }
 }

--- a/src/Valit/Rules/Extensions/ValitRuleEnumerableExtensions.cs
+++ b/src/Valit/Rules/Extensions/ValitRuleEnumerableExtensions.cs
@@ -1,17 +1,19 @@
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Valit
 {
     public static class ValitRuleEnumerableExtensions
     {     
 
-        public static IValitRule<TObject, IEnumerable> MinItems<TObject>(this IValitRule<TObject, IEnumerable> rule, int expectedItemsNumber) where TObject : class
+        public static IValitRule<TObject, IEnumerable<TProperty>> MinItems<TObject, TProperty>(this IValitRule<TObject, IEnumerable<TProperty>> rule, int expectedItemsNumber) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);             
             return rule.Satisfies(p => p != null && p.Count() >= expectedItemsNumber);
         }
 
-        public static IValitRule<TObject, IEnumerable> MaxItems<TObject>(this IValitRule<TObject, IEnumerable> rule, int expectedItemsNumber) where TObject : class
+        public static IValitRule<TObject, IEnumerable<TProperty>> MaxItems<TObject, TProperty>(this IValitRule<TObject, IEnumerable<TProperty>> rule, int expectedItemsNumber) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);             
             return rule.Satisfies(p => p != null && p.Count() <= expectedItemsNumber);

--- a/src/Valit/Rules/ValitRule.cs
+++ b/src/Valit/Rules/ValitRule.cs
@@ -64,6 +64,8 @@ namespace Valit
 
         public IValitResult Validate(TObject @object)
 		{
+            @object.ThrowIfNull();
+
             var property = _propertySelector(@object);
 			var hasAllConditionsFulfilled = true;
 

--- a/tests/Valit.Tests/Enumerable/Enumerable_MaxItems_Tests.cs
+++ b/tests/Valit.Tests/Enumerable/Enumerable_MaxItems_Tests.cs
@@ -1,0 +1,88 @@
+using System.Collections;
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+
+namespace Valit.Tests.Enumerable
+{
+    public class Enumerable_MaxItems_Tests
+    {
+        [Fact]
+        public void Enumerable_MaxItems_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, IEnumerable<int>>)null)
+                    .MaxItems(1);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }       
+
+        [Fact]
+        public void Enumerable_MaxItems_Succeeds_If_ExpectedItemsNumber_Is_Greater_Than_Number_Of_Items_In_Collection()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Collection, _=>_
+                    .MaxItems(5))
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }   
+
+        [Fact]
+        public void Enumerable_MaxItems_Succeeds_If_ExpectedItemsNumber_Is_Equal_To_Number_Of_Items_In_Collection()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Collection, _=>_
+                    .MaxItems(3))
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }  
+
+        [Fact]
+        public void Enumerable_MaxItems_Fails_If_ExpectedItemsNumber_Is_Less_Than_Number_Of_Items_In_Collection()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Collection, _=>_
+                    .MaxItems(2))
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void Enumerable_MaxItems_Fails_If_Null_Collection_Is_Given()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullCollection, _=>_
+                    .MaxItems(5))
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }   
+
+#region ARRANGE
+        public Enumerable_MaxItems_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public IEnumerable<int> Collection => new List<int> { 1, 2, 3 };
+            public IEnumerable<int> NullCollection => null;
+        }
+#endregion  
+    }
+}

--- a/tests/Valit.Tests/Enumerable/Enumerable_MinItems_Tests.cs
+++ b/tests/Valit.Tests/Enumerable/Enumerable_MinItems_Tests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+
+namespace Valit.Tests.Enumerable
+{
+    public class Enumerable_MinItems_Tests
+    {
+        [Fact]
+        public void Enumerable_MinItems_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, IEnumerable<int>>)null)
+                    .MinItems(1);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }       
+
+        [Fact]
+        public void Enumerable_MinItems_Succeeds_If_ExpectedItemsNumber_Is_Less_Than_Number_Of_Items_In_Collection()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Collection, _=>_
+                    .MinItems(1))
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }   
+
+        [Fact]
+        public void Enumerable_MinItems_Succeeds_If_ExpectedItemsNumber_Is_Equal_To_Number_Of_Items_In_Collection()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Collection, _=>_
+                    .MinItems(3))
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }  
+
+        [Fact]
+        public void Enumerable_MinItems_Fails_If_ExpectedItemsNumber_Is_Greater_Than_Number_Of_Items_In_Collection()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Collection, _=>_
+                    .MinItems(5))
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }  
+
+        [Fact]
+        public void Enumerable_MaxItems_Fails_If_Null_Collection_Is_Given()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullCollection, _=>_
+                    .MinItems(1))
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }  
+
+
+#region ARRANGE
+        public Enumerable_MinItems_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public IEnumerable<int> Collection => new List<int> { 1, 2, 3 };
+            public IEnumerable<int> NullCollection => null;
+        }
+#endregion  
+    }
+}


### PR DESCRIPTION
I added unit test for IEnumerable<T>:
- MaxItems()
- MinItems()

I also changed extension methods which accepted non-generic version of IEnumerable. I'm not quite sure why I did that :D Last thing was adding null check to Validate method because it caused NullReferenceException if object wasn't passed using For() method.