### PR TITLE
Added unit tests for DateTime type. Removed SameAsNow & SameAsUtcNow.

### DIFF
--- a/src/Valit/ValitRuleDateTimeExtensions.cs
+++ b/src/Valit/ValitRuleDateTimeExtensions.cs
@@ -53,49 +53,49 @@ namespace Valit
             return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value < datetime.Value);
         }
 
-        public static IValitRule<TObject, DateTime> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
+        public static IValitRule<TObject, DateTime> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p >= datetime);
         }
 
-        public static IValitRule<TObject, DateTime> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
+        public static IValitRule<TObject, DateTime> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => datetime.HasValue && p >= datetime.Value);
         }
 
-        public static IValitRule<TObject, DateTime?> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
+        public static IValitRule<TObject, DateTime?> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && p.Value >= datetime);
         }
 
-        public static IValitRule<TObject, DateTime?> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
+        public static IValitRule<TObject, DateTime?> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value >= datetime.Value);
         }
 
-        public static IValitRule<TObject, DateTime> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
+        public static IValitRule<TObject, DateTime> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p <= datetime);
         }
 
-        public static IValitRule<TObject, DateTime> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
+        public static IValitRule<TObject, DateTime> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => datetime.HasValue && p <= datetime.Value);
         }
 
-        public static IValitRule<TObject, DateTime?> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
+        public static IValitRule<TObject, DateTime?> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && p.Value <= datetime);
         }
 
-        public static IValitRule<TObject, DateTime?> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
+        public static IValitRule<TObject, DateTime?> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value <= datetime.Value);
@@ -149,73 +149,25 @@ namespace Valit
             return rule.Satisfies(p => p.HasValue && p.Value < DateTime.UtcNow);
         }
 
-        public static IValitRule<TObject, DateTime> IsAfterOrEqualToNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p >= DateTime.Now);
-        }
-
-        public static IValitRule<TObject, DateTime?> IsAfterOrEqualToNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p.HasValue && p.Value >= DateTime.Now);
-        }
-
-        public static IValitRule<TObject, DateTime> IsBeforeOrEqualToNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p <= DateTime.Now);
-        }
-
-        public static IValitRule<TObject, DateTime?> IsBeforeOrEqualToNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p.HasValue && p.Value <= DateTime.Now);
-        }
-
-        public static IValitRule<TObject, DateTime> IsAfterOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p >= DateTime.UtcNow);
-        }
-
-        public static IValitRule<TObject, DateTime?> IsAfterOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p.HasValue && p.Value >= DateTime.UtcNow);
-        }
-
-        public static IValitRule<TObject, DateTime> IsBeforeOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p <= DateTime.UtcNow);
-        }
-
-        public static IValitRule<TObject, DateTime?> IsBeforeOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p.HasValue && p.Value <= DateTime.UtcNow);
-        }
-
-        public static IValitRule<TObject, DateTime> IsEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
+        public static IValitRule<TObject, DateTime> IsSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p == datetime);
         }
 
-        public static IValitRule<TObject, DateTime> IsEqualTo<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
+        public static IValitRule<TObject, DateTime> IsSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => datetime.HasValue && p == datetime.Value);
         }
 
-        public static IValitRule<TObject, DateTime?> IsEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
+        public static IValitRule<TObject, DateTime?> IsSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && p.Value == datetime);
         }
 
-        public static IValitRule<TObject, DateTime?> IsEqualTo<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
+        public static IValitRule<TObject, DateTime?> IsSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value == datetime.Value);

--- a/src/Valit/ValitRuleDateTimeOffsetExtensions.cs
+++ b/src/Valit/ValitRuleDateTimeOffsetExtensions.cs
@@ -53,49 +53,49 @@ namespace Valit
             return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value < dateTimeOffset.Value);
         }
 
-        public static IValitRule<TObject, DateTimeOffset> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p >= dateTimeOffset);
         }
 
-        public static IValitRule<TObject, DateTimeOffset> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => dateTimeOffset.HasValue && p >= dateTimeOffset.Value);
         }
 
-        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && p.Value >= dateTimeOffset);
         }
 
-        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value >= dateTimeOffset.Value);
         }
 
-        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p <= dateTimeOffset);
         }
 
-        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => dateTimeOffset.HasValue && p <= dateTimeOffset.Value);
         }
 
-        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && p.Value <= dateTimeOffset);
         }
 
-        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value <= dateTimeOffset.Value);
@@ -147,75 +147,27 @@ namespace Valit
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && p.Value < DateTimeOffset.UtcNow);
-        }
+        }     
 
-        public static IValitRule<TObject, DateTimeOffset> IsAfterOrEqualToNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p >= DateTimeOffset.Now);
-        }
-
-        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrEqualToNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p.HasValue && p.Value >= DateTimeOffset.Now);
-        }
-
-        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrEqualToNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p <= DateTimeOffset.Now);
-        }
-
-        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrEqualToNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p.HasValue && p.Value <= DateTimeOffset.Now);
-        }
-
-        public static IValitRule<TObject, DateTimeOffset> IsAfterOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p >= DateTimeOffset.UtcNow);
-        }
-
-        public static IValitRule<TObject, DateTimeOffset?> IsAfterOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p.HasValue && p.Value >= DateTimeOffset.UtcNow);
-        }
-
-        public static IValitRule<TObject, DateTimeOffset> IsBeforeOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p <= DateTimeOffset.UtcNow);
-        }
-
-        public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrEqualToUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-        {
-            rule.ThrowIfNull(ValitExceptionMessages.NullRule);
-            return rule.Satisfies(p => p.HasValue && p.Value <= DateTimeOffset.UtcNow);
-        }
-
-        public static IValitRule<TObject, DateTimeOffset> IsEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset> IsSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p == dateTimeOffset);
         }
 
-        public static IValitRule<TObject, DateTimeOffset> IsEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset> IsSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => dateTimeOffset.HasValue && p == dateTimeOffset.Value);
         }
 
-        public static IValitRule<TObject, DateTimeOffset?> IsEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset?> IsSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && p.Value == dateTimeOffset);
         }
 
-        public static IValitRule<TObject, DateTimeOffset?> IsEqualTo<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
+        public static IValitRule<TObject, DateTimeOffset?> IsSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
         {
             rule.ThrowIfNull(ValitExceptionMessages.NullRule);
             return rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value == dateTimeOffset.Value);

--- a/tests/Valit.Tests/DateTime_/DateTime_IsAfterNow_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsAfterNow_Tests.cs
@@ -1,0 +1,115 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsAfterNow_Tests
+    {
+       [Fact]
+        public void DateTime_IsAfterNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsAfterNow();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsAfterNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsAfterNow();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsAfterNow_For_Not_Nullable_Value_Succeeds_When_Value_Is_After_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.AfterNowValue, _=>_
+                    .IsAfterNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsAfterNow_For_Not_Nullable_Value_Fails_When_Value_Is_Before_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.BeforeNowValue, _=>_
+                    .IsAfterNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsAfterNow_For_Nullable_Value_Succeeds_When_Value_Is_After_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullableAfterNowValue, _=>_
+                    .IsAfterNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsAfterNow_For_Nullable_Value_Fails_When_Value_Is_Before_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                    .IsAfterNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsAfterNow_For_Nullable_Value_Fails_When_Value_Is_Null()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullValue, _=>_
+                    .IsAfterNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+#region ARRANGE
+        public DateTime_IsAfterNow_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime BeforeNowValue => DateTime.Now.AddDays(-1);            
+            public DateTime AfterNowValue => DateTime.Now.AddDays(1);
+            public DateTime? NullableBeforeNowValue => DateTime.Now.AddDays(-1);
+            public DateTime? NullableAfterNowValue => DateTime.Now.AddDays(1);
+            public DateTime? NullValue => null;
+        }
+#endregion 
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_IsAfterOrSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsAfterOrSameAs_Tests.cs
@@ -1,0 +1,143 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsAfterOrSameAs_Tests
+    {
+        [Fact]
+        public void DateTime_IsAfterOrSameAs_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsAfterOrSameAs(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsAfterOrSameAs_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsAfterOrSameAs((DateTime?)DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsAfterOrSameAs_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsAfterOrSameAs(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }    
+
+        [Fact]
+        public void DateTime_IsAfterOrSameAs_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsAfterOrSameAs((DateTime?) DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Theory]
+        [InlineData("2017-06-09", true)]
+        [InlineData("2017-06-10", true)]
+        [InlineData("2017-06-11", false)]     
+        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsAfterOrSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }   
+
+        [Theory]
+        [InlineData("2017-06-09", true)]
+        [InlineData("2017-06-10", true)]
+        [InlineData("2017-06-11", false)]     
+        [InlineData(null, false)]     
+        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        {            
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsAfterOrSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-09", true)]
+        [InlineData(false, "2017-06-10", true)]        
+        [InlineData(false, "2017-06-11", false)]     
+        [InlineData(true, "2017-06-09", false)]     
+        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsAfterOrSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-09", true)] 
+        [InlineData(false, "2017-06-10", true)]    
+        [InlineData(false, "2017-06-11", false)]
+        [InlineData(false, null, false)]     
+        [InlineData(true, "2017-06-09", false)]     
+        [InlineData(true, null, false)]     
+        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        {    
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsAfterOrSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+#region ARRANGE
+        public DateTime_IsAfterOrSameAs_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime Value => new DateTime(2017, 6, 10);
+            public DateTime? NullableValue => new DateTime(2017, 6, 10);
+            public DateTime? NullValue => null;
+        }
+#endregion   
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_IsAfterUtcNow_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsAfterUtcNow_Tests.cs
@@ -1,0 +1,115 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsAfterUtcNow_Tests
+    {
+       [Fact]
+        public void DateTime_IsAfterUtcNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsAfterUtcNow();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsAfterUtcNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsAfterUtcNow();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsAfterUtcNow_For_Not_Nullable_Value_Succeeds_When_Value_Is_After_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.AfterNowValue, _=>_
+                    .IsAfterUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsAfterUtcNow_For_Not_Nullable_Value_Fails_When_Value_Is_Before_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.BeforeNowValue, _=>_
+                    .IsAfterUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsAfterUtcNow_For_Nullable_Value_Succeeds_When_Value_Is_After_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullableAfterNowValue, _=>_
+                    .IsAfterUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsAfterUtcNow_For_Nullable_Value_Fails_When_Value_Is_Before_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                    .IsAfterUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsAfterUtcNow_For_Nullable_Value_Fails_When_Value_Is_Null()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullValue, _=>_
+                    .IsAfterUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+#region ARRANGE
+        public DateTime_IsAfterUtcNow_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime BeforeNowValue => DateTime.UtcNow.AddDays(-1);            
+            public DateTime AfterNowValue => DateTime.UtcNow.AddDays(1);
+            public DateTime? NullableBeforeNowValue => DateTime.UtcNow.AddDays(-1);
+            public DateTime? NullableAfterNowValue => DateTime.UtcNow.AddDays(1);
+            public DateTime? NullValue => null;
+        }
+#endregion 
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_IsAfter_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsAfter_Tests.cs
@@ -1,0 +1,143 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsAfter_Tests
+    {
+        [Fact]
+        public void DateTime_IsAfter_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsAfter(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsAfter_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsAfter((DateTime?)DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsAfter_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsAfter(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }    
+
+        [Fact]
+        public void DateTime_IsAfter_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsAfter((DateTime?) DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Theory]
+        [InlineData("2017-06-09", true)]
+        [InlineData("2017-06-10", false)]
+        [InlineData("2017-06-11", false)]     
+        public void DateTime_IsAfter_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsAfter(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }   
+
+        [Theory]
+        [InlineData("2017-06-09", true)]
+        [InlineData("2017-06-10", false)]
+        [InlineData("2017-06-11", false)]     
+        [InlineData(null, false)]     
+        public void DateTime_IsAfter_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        {            
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsAfter(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-09", true)]
+        [InlineData(false, "2017-06-10", false)]        
+        [InlineData(false, "2017-06-11", false)]     
+        [InlineData(true, "2017-06-09", false)]     
+        public void DateTime_IsAfter_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsAfter(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-09", true)] 
+        [InlineData(false, "2017-06-10", false)]    
+        [InlineData(false, "2017-06-11", false)]
+        [InlineData(false, null, false)]     
+        [InlineData(true, "2017-06-09", false)]     
+        [InlineData(true, null, false)]     
+        public void DateTime_IsAfter_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        {    
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsAfter(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+#region ARRANGE
+        public DateTime_IsAfter_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime Value => new DateTime(2017, 6, 10);
+            public DateTime? NullableValue => new DateTime(2017, 6, 10);
+            public DateTime? NullValue => null;
+        }
+#endregion 
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_IsBeforeNow_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsBeforeNow_Tests.cs
@@ -1,0 +1,115 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsBeforeNow_Tests
+    {
+       [Fact]
+        public void DateTime_IsBeforeNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsBeforeNow();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsBeforeNow();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeNow_For_Not_Nullable_Value_Succeeds_When_Value_Is_Before_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.BeforeNowValue, _=>_
+                    .IsBeforeNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeNow_For_Not_Nullable_Value_Fails_When_Value_Is_After_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.AfterNowValue, _=>_
+                    .IsBeforeNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeNow_For_Nullable_Value_Succeeds_When_Value_Is_Before_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                    .IsBeforeNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeNow_For_Nullable_Value_Fails_When_Value_Is_After_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullableAfterNowValue, _=>_
+                    .IsBeforeNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeNow_For_Nullable_Value_Fails_When_Value_Is_Null()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullValue, _=>_
+                    .IsBeforeNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+#region ARRANGE
+        public DateTime_IsBeforeNow_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime BeforeNowValue => DateTime.Now.AddDays(-1);            
+            public DateTime AfterNowValue => DateTime.Now.AddDays(1);
+            public DateTime? NullableBeforeNowValue => DateTime.Now.AddDays(-1);
+            public DateTime? NullableAfterNowValue => DateTime.Now.AddDays(1);
+            public DateTime? NullValue => null;
+        }
+#endregion  
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_IsBeforeOrSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsBeforeOrSameAs_Tests.cs
@@ -1,0 +1,143 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsBeforeOrSameAs_Tests
+    {
+        [Fact]
+        public void DateTime_IsBeforeOrSameAs_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsBeforeOrSameAs(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeOrSameAs_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsBeforeOrSameAs((DateTime?)DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeOrSameAs_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsBeforeOrSameAs(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }    
+
+        [Fact]
+        public void DateTime_IsBeforeOrSameAs_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsBeforeOrSameAs((DateTime?) DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Theory]
+        [InlineData("2017-06-11", true)]
+        [InlineData("2017-06-10", true)]
+        [InlineData("2017-06-09", false)]     
+        public void DateTime_IsBeforeOrSameAs_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsBeforeOrSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }   
+
+        [Theory]
+        [InlineData("2017-06-11", true)]
+        [InlineData("2017-06-10", true)]
+        [InlineData("2017-06-09", false)]     
+        [InlineData(null, false)]     
+        public void DateTime_IsBeforeOrSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        {            
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsBeforeOrSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-11", true)]
+        [InlineData(false, "2017-06-10", true)]        
+        [InlineData(false, "2017-06-09", false)]     
+        [InlineData(true, "2017-06-11", false)]     
+        public void DateTime_IsBeforeOrSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsBeforeOrSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-11", true)] 
+        [InlineData(false, "2017-06-10", true)]    
+        [InlineData(false, "2017-06-09", false)]
+        [InlineData(false, null, false)]     
+        [InlineData(true, "2017-06-11", false)]     
+        [InlineData(true, null, false)]     
+        public void DateTime_IsBeforeOrSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        {    
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsBeforeOrSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+#region ARRANGE
+        public DateTime_IsBeforeOrSameAs_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime Value => new DateTime(2017, 6, 10);
+            public DateTime? NullableValue => new DateTime(2017, 6, 10);
+            public DateTime? NullValue => null;
+        }
+#endregion    
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_IsBeforeUtcNow_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsBeforeUtcNow_Tests.cs
@@ -1,0 +1,115 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsBeforeUtcNow_Tests
+    {
+       [Fact]
+        public void DateTime_IsBeforeUtcNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsBeforeUtcNow();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeUtcNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsBeforeUtcNow();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeUtcNow_For_Not_Nullable_Value_Succeeds_When_Value_Is_Before_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.BeforeNowValue, _=>_
+                    .IsBeforeUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeUtcNow_For_Not_Nullable_Value_Fails_When_Value_Is_After_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.AfterNowValue, _=>_
+                    .IsBeforeUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeUtcNow_For_Nullable_Value_Succeeds_When_Value_Is_Before_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                    .IsBeforeUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeUtcNow_For_Nullable_Value_Fails_When_Value_Is_After_DateTime_Now()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullableAfterNowValue, _=>_
+                    .IsBeforeUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void DateTime_IsBeforeUtcNow_For_Nullable_Value_Fails_When_Value_Is_Null()
+        {
+            var result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NullValue, _=>_
+                    .IsBeforeUtcNow())
+                .For(_model)
+                .Validate();
+            
+            Assert.False(result.Succeeded);
+        }
+
+#region ARRANGE
+        public DateTime_IsBeforeUtcNow_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime BeforeNowValue => DateTime.UtcNow.AddDays(-1);            
+            public DateTime AfterNowValue => DateTime.UtcNow.AddDays(1);
+            public DateTime? NullableBeforeNowValue => DateTime.UtcNow.AddDays(-1);
+            public DateTime? NullableAfterNowValue => DateTime.UtcNow.AddDays(1);
+            public DateTime? NullValue => null;
+        }
+#endregion  
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_IsBefore_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsBefore_Tests.cs
@@ -1,0 +1,143 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsBefore_Tests
+    {
+        [Fact]
+        public void DateTime_IsBefore_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsBefore(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsBefore_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsBefore((DateTime?)DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsBefore_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsBefore(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }    
+
+        [Fact]
+        public void DateTime_IsBefore_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsBefore((DateTime?) DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Theory]
+        [InlineData("2017-06-11", true)]
+        [InlineData("2017-06-10", false)]
+        [InlineData("2017-06-09", false)]     
+        public void DateTime_IsBefore_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsBefore(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }   
+
+        [Theory]
+        [InlineData("2017-06-11", true)]
+        [InlineData("2017-06-10", false)]
+        [InlineData("2017-06-09", false)]     
+        [InlineData(null, false)]     
+        public void DateTime_IsBefore_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        {            
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsBefore(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-11", true)]
+        [InlineData(false, "2017-06-10", false)]        
+        [InlineData(false, "2017-06-09", false)]     
+        [InlineData(true, "2017-06-11", false)]     
+        public void DateTime_IsBefore_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsBefore(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-11", true)] 
+        [InlineData(false, "2017-06-10", false)]    
+        [InlineData(false, "2017-06-09", false)]
+        [InlineData(false, null, false)]     
+        [InlineData(true, "2017-06-11", false)]     
+        [InlineData(true, null, false)]     
+        public void DateTime_IsBefore_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        {    
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsBefore(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+#region ARRANGE
+        public DateTime_IsBefore_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime Value => new DateTime(2017, 6, 10);
+            public DateTime? NullableValue => new DateTime(2017, 6, 10);
+            public DateTime? NullValue => null;
+        }
+#endregion 
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_IsSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsSameAs_Tests.cs
@@ -1,0 +1,143 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_IsSameAs_Tests
+    {
+        [Fact]
+        public void DateTime_IsSameAs_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsSameAs(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsSameAs_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime>)null)
+                    .IsSameAs((DateTime?)DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void DateTime_IsSameAs_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsSameAs(DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }    
+
+        [Fact]
+        public void DateTime_IsSameAs_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, DateTime?>)null)
+                    .IsSameAs((DateTime?) DateTime.Now);
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Theory]
+        [InlineData("2017-06-10", true)]
+        [InlineData("2017-06-09", false)]
+        [InlineData("2017-06-11", false)]     
+        public void DateTime_IsSameAs_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }   
+
+        [Theory]
+        [InlineData("2017-06-10", true)]
+        [InlineData("2017-06-09", false)]
+        [InlineData("2017-06-11", false)]     
+        [InlineData(null, false)]     
+        public void DateTime_IsSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        {            
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.Value, _=>_
+                    .IsSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-10", true)]
+        [InlineData(false, "2017-06-09", false)]        
+        [InlineData(false, "2017-06-11", false)]     
+        [InlineData(true, "2017-06-10", false)]     
+        public void DateTime_IsSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-06-10", true)] 
+        [InlineData(false, "2017-06-09", false)]    
+        [InlineData(false, "2017-06-11", false)]
+        [InlineData(false, null, false)]     
+        [InlineData(true, "2017-06-10", false)]     
+        [InlineData(true, null, false)]     
+        public void DateTime_IsSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        {    
+            DateTime? value = stringValue.AsNullableDateTime();
+
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .IsSameAs(value))
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+#region ARRANGE
+        public DateTime_IsSameAs_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime Value => new DateTime(2017, 6, 10);
+            public DateTime? NullableValue => new DateTime(2017, 6, 10);
+            public DateTime? NullValue => null;
+        }
+#endregion 
+    }
+}

--- a/tests/Valit.Tests/DateTime_/DateTime_Required_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_Required_Tests.cs
@@ -1,0 +1,52 @@
+using System;
+using Shouldly;
+using Valit.Tests.HelperExtensions;
+using Xunit;
+
+namespace Valit.Tests.DateTime_
+{
+    public class DateTime_Required_Tests
+    {
+        [Fact]
+        public void DateTime_Required_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ((IValitRule<Model, short?>)null)
+                    .Required();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+
+        [Theory]
+        [InlineData(false, true)]
+        [InlineData(true, false)] 
+        public void DateTime_Required_Returns_Proper_Results_For_Nullable_Value(bool useNullValue,  bool expected)
+        {            
+            IValitResult result = ValitRules<Model>
+                .Create()
+                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                    .Required())
+                .For(_model)
+                .Validate();
+
+            Assert.Equal(result.Succeeded, expected);
+        }
+
+#region ARRANGE
+        public DateTime_Required_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public DateTime? NullableValue => DateTime.Now;
+            public DateTime? NullValue => null;
+        }
+#endregion
+    }
+}

--- a/tests/Valit.Tests/HelperExtensions/DateTimeExtensions.cs
+++ b/tests/Valit.Tests/HelperExtensions/DateTimeExtensions.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Valit.Tests.HelperExtensions
+{
+    public static class DateTimeExtensions
+    {
+        public static DateTime? AsNullableDateTime(this string stringValue)
+            => string.IsNullOrWhiteSpace(stringValue)? (DateTime?)null : Convert.ToDateTime(stringValue);
+
+    }
+}

--- a/tests/Valit.Tests/HelperExtensions/DateTimeOffsetExtensions.cs
+++ b/tests/Valit.Tests/HelperExtensions/DateTimeOffsetExtensions.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Valit.Tests.HelperExtensions
+{
+    public static class DateTimeOffsetExtensions
+    {
+        public static DateTimeOffset? AsNullableDateTimeOffset(this string stringValue)
+            => string.IsNullOrWhiteSpace(stringValue)? (DateTimeOffset?)null : Convert.ToDateTime(stringValue);
+    }
+}


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. 74 ( #74 ) 

# Changes
- Added unit tests for all DateTime extensions methods. Removed all IsAfterOr... and IsBeforeOr...
