### PR TITLE
Added support for nested object validation

### DIFF
--- a/src/Valit/IValitRules.cs
+++ b/src/Valit/IValitRules.cs
@@ -6,6 +6,7 @@ namespace Valit
     public interface IValitRules<TObject> where TObject : class
     {
          IValitRules<TObject> Ensure<TProperty>(Func<TObject, TProperty> selector, Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> rule);
+         IValitRules<TObject> Ensure<TProperty>(Func<TObject, TProperty> selector, IValitRulesProvider<TProperty> valitRulesProvider) where TProperty : class;
          IValitRules<TObject> For(TObject @object);
          IEnumerable<IValitRule<TObject>> GetAllRules();         
          IEnumerable<IValitRule<TObject>> GetTaggedRules();

--- a/src/Valit/IValitRulesProvider.cs
+++ b/src/Valit/IValitRulesProvider.cs
@@ -4,6 +4,6 @@ namespace Valit
 {
     public interface IValitRulesProvider<TObject> where TObject : class
     {
-         IEnumerable<IValitRule<TObject>> GetValitRules();
+         IEnumerable<IValitRule<TObject>> GetRules();
     }
 }

--- a/src/Valit/IValitRulesProvider.cs
+++ b/src/Valit/IValitRulesProvider.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Valit
+{
+    public interface IValitRulesProvider<TObject> where TObject : class
+    {
+         IEnumerable<IValitRule<TObject>> GetValitRules();
+    }
+}

--- a/src/Valit/IValitator.cs
+++ b/src/Valit/IValitator.cs
@@ -1,0 +1,7 @@
+namespace Valit
+{
+    public interface IValitator<in TObject> where TObject : class
+    {
+         IValitResult Validate(TObject @object, IValitStrategy strategy = null); 
+    }
+}

--- a/src/Valit/Rules/NestedObjectValitRule.cs
+++ b/src/Valit/Rules/NestedObjectValitRule.cs
@@ -8,18 +8,16 @@ namespace Valit.Rules
 	{
 		public IEnumerable<string> Tags => Enumerable.Empty<string>();
         private readonly Func<TObject, TProperty> _propertySelector;
-        private readonly IValitRulesProvider<TProperty> _valitRulesProvider; 
-        private readonly IValitMessageProvider _messageProvider;
+        private readonly IValitRulesProvider<TProperty> _valitRulesProvider;
         private readonly IValitStrategy _strategy;
 
         public NestedObjectValitRule(
             Func<TObject, TProperty> selector, 
-            IValitRulesProvider<TProperty> valitRulesProvider, 
-            IValitMessageProvider messageProvider, IValitStrategy strategy)
+            IValitRulesProvider<TProperty> valitRulesProvider,
+            IValitStrategy strategy)
         {
             _propertySelector = selector;
             _valitRulesProvider = valitRulesProvider;
-            _messageProvider = messageProvider;
             _strategy = strategy;
         }
 
@@ -30,7 +28,6 @@ namespace Valit.Rules
 
             return ValitRules<TProperty>
                 .Create(valitRules)
-                .WithMessageProvider(_messageProvider as IValitMessageProvider<TObject>)
                 .WithStrategy(_strategy)
                 .For(property)
                 .Validate();

--- a/src/Valit/Rules/NestedObjectValitRule.cs
+++ b/src/Valit/Rules/NestedObjectValitRule.cs
@@ -23,7 +23,7 @@ namespace Valit.Rules
 
 		public IValitResult Validate(TObject @object)
         {
-            var valitRules = _valitRulesProvider.GetValitRules();
+            var valitRules = _valitRulesProvider.GetRules();
             var property = _propertySelector(@object);
 
             return ValitRules<TProperty>

--- a/src/Valit/Rules/NestedObjectValitRule.cs
+++ b/src/Valit/Rules/NestedObjectValitRule.cs
@@ -31,8 +31,6 @@ namespace Valit.Rules
                 .WithStrategy(_strategy)
                 .For(property)
                 .Validate();
-        }
-                    
-
+        }                  
 	}
 }

--- a/src/Valit/Rules/NestedObjectValitRule.cs
+++ b/src/Valit/Rules/NestedObjectValitRule.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Valit.Rules
+{
+	internal class NestedObjectValitRule<TObject, TProperty> : IValitRule<TObject> where TObject : class where TProperty : class
+	{
+		public IEnumerable<string> Tags => Enumerable.Empty<string>();
+        private readonly Func<TObject, TProperty> _propertySelector;
+        private readonly IValitRulesProvider<TProperty> _valitRulesProvider; 
+        private readonly IValitMessageProvider _messageProvider;
+        private readonly IValitStrategy _strategy;
+
+        public NestedObjectValitRule(
+            Func<TObject, TProperty> selector, 
+            IValitRulesProvider<TProperty> valitRulesProvider, 
+            IValitMessageProvider messageProvider, IValitStrategy strategy)
+        {
+            _propertySelector = selector;
+            _valitRulesProvider = valitRulesProvider;
+            _messageProvider = messageProvider;
+            _strategy = strategy;
+        }
+
+		public IValitResult Validate(TObject @object)
+        {
+            var valitRules = _valitRulesProvider.GetValitRules();
+            var property = _propertySelector(@object);
+
+            return ValitRules<TProperty>
+                .Create(valitRules)
+                .WithMessageProvider(_messageProvider as IValitMessageProvider<TObject>)
+                .WithStrategy(_strategy)
+                .For(property)
+                .Validate();
+        }
+                    
+
+	}
+}

--- a/src/Valit/Rules/NestedObjectValitRule.cs
+++ b/src/Valit/Rules/NestedObjectValitRule.cs
@@ -6,7 +6,7 @@ namespace Valit.Rules
 {
 	internal class NestedObjectValitRule<TObject, TProperty> : IValitRule<TObject> where TObject : class where TProperty : class
 	{
-		public IEnumerable<string> Tags => Enumerable.Empty<string>();
+		IEnumerable<string> IValitRule.Tags => Enumerable.Empty<string>();
         private readonly Func<TObject, TProperty> _propertySelector;
         private readonly IValitRulesProvider<TProperty> _valitRulesProvider;
         private readonly IValitStrategy _strategy;

--- a/src/Valit/Validators/Valitator.cs
+++ b/src/Valit/Validators/Valitator.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Valit.Validators
+{
+	internal sealed class Valitator<TObject> : IValitator<TObject> where TObject : class
+	{
+        private readonly IValitRulesStrategyPicker<TObject> _strategyPicker;
+
+        internal Valitator(IValitRulesProvider<TObject> valitRulesProvider)
+        {
+            _strategyPicker = CreateStrategyPicker(valitRulesProvider);
+        }
+
+		IValitResult IValitator<TObject>.Validate(TObject @object, IValitStrategy strategy = null)
+		{
+			var selectedStrategy = strategy ?? new CompleteValitStrategy();
+
+            return _strategyPicker
+                .WithStrategy(selectedStrategy)
+                .For(@object)
+                .Validate();
+		}
+
+        private IValitRulesStrategyPicker<TObject> CreateStrategyPicker(IValitRulesProvider<TObject> valitRulesProvider)
+        {
+            var rules = valitRulesProvider.GetRules();
+            return ValitRules<TObject>.Create(rules);
+        }
+	}
+}

--- a/src/Valit/Validators/Valitator.cs
+++ b/src/Valit/Validators/Valitator.cs
@@ -11,7 +11,7 @@ namespace Valit.Validators
             _strategyPicker = CreateStrategyPicker(valitRulesProvider);
         }
 
-		IValitResult IValitator<TObject>.Validate(TObject @object, IValitStrategy strategy = null)
+		IValitResult IValitator<TObject>.Validate(TObject @object, IValitStrategy strategy)
 		{
 			var selectedStrategy = strategy ?? new CompleteValitStrategy();
 

--- a/src/Valit/ValitRules.cs
+++ b/src/Valit/ValitRules.cs
@@ -49,7 +49,7 @@ namespace Valit
 
         IValitRules<TObject> IValitRules<TObject>.Ensure<TProperty>(Func<TObject, TProperty> selector, IValitRulesProvider<TProperty> valitRulesProvider)
         {                       
-            IValitRule<TObject> nestedValitRule = new NestedObjectValitRule<TObject, TProperty>(selector, valitRulesProvider, _messageProvider, _strategy);
+            var nestedValitRule = new NestedObjectValitRule<TObject, TProperty>(selector, valitRulesProvider, _strategy);
             _rules.Add(nestedValitRule);
             return this;
         }

--- a/src/Valit/ValitRules.cs
+++ b/src/Valit/ValitRules.cs
@@ -43,12 +43,18 @@ namespace Valit
 
         IValitRules<TObject> IValitRules<TObject>.Ensure<TProperty>(Func<TObject, TProperty> selector, Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> ruleFunc)
         {                       
+            selector.ThrowIfNull();
+            ruleFunc.ThrowIfNull();
+
             AddEnsureRulesAccessors(selector, ruleFunc);
             return this;
         }
 
         IValitRules<TObject> IValitRules<TObject>.Ensure<TProperty>(Func<TObject, TProperty> selector, IValitRulesProvider<TProperty> valitRulesProvider)
         {                       
+            selector.ThrowIfNull();
+            valitRulesProvider.ThrowIfNull();
+
             var nestedValitRule = new NestedObjectValitRule<TObject, TProperty>(selector, valitRulesProvider, _strategy);
             _rules.Add(nestedValitRule);
             return this;

--- a/src/Valit/ValitRules.cs
+++ b/src/Valit/ValitRules.cs
@@ -47,6 +47,13 @@ namespace Valit
             return this;
         }
 
+        IValitRules<TObject> IValitRules<TObject>.Ensure<TProperty>(Func<TObject, TProperty> selector, IValitRulesProvider<TProperty> valitRulesProvider)
+        {                       
+            IValitRule<TObject> nestedValitRule = new NestedObjectValitRule<TObject, TProperty>(selector, valitRulesProvider, _messageProvider, _strategy);
+            _rules.Add(nestedValitRule);
+            return this;
+        }
+
         IValitRules<TObject> IValitRules<TObject>.For(TObject @object)
         {
             @object.ThrowIfNull();

--- a/src/Valit/ValitRulesProviderExtensions.cs
+++ b/src/Valit/ValitRulesProviderExtensions.cs
@@ -1,0 +1,14 @@
+using Valit.Exceptions;
+using Valit.Validators;
+
+namespace Valit
+{
+    public static class ValitRulesProviderExtensions
+    {
+        public static IValitator<TObject> CreateValitator<TObject>(this IValitRulesProvider<TObject> valitRulesProvider) where TObject : class
+        {
+            valitRulesProvider.ThrowIfNull();
+            return new Valitator<TObject>(valitRulesProvider);
+        }
+    }
+}

--- a/tests/Valit.Tests/ValitRulesProvider/NestedObject_Validation_Tests.cs
+++ b/tests/Valit.Tests/ValitRulesProvider/NestedObject_Validation_Tests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+
+namespace Valit.Tests.ValitRulesProvider
+{
+    public class NestedObject_Validation_Tests
+    {
+
+        [Fact]
+        public void Ensure_Throws_When_Null_ValitRulesProvider_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                ValitRules<RootObject>
+                    .Create()
+                    .Ensure(m => m.NestedObject, ((IValitRulesProvider<NestedObject>)null));
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void Validation_Fails_When_Invalid_NestedObject_Is_Given()
+        {
+            var rootObject = RootObject.GetInvalid();
+
+            var result = ValitRules<RootObject>
+                .Create()
+                .Ensure(m => m.StringValue, _=>_
+                    .Required())
+                .Ensure(m => m.NestedObject, new NestedObjectRulesProvider())
+                .For(rootObject)
+                .Validate();
+
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public void Validation_Returns_Proper_Messages_When_Invalid_NestedObject_Is_Given()
+        {
+            var rootObject = RootObject.GetInvalid();
+            
+            var result = ValitRules<RootObject>
+                .Create()
+                .Ensure(m => m.StringValue, _=>_
+                    .Required())
+                .Ensure(m => m.NestedObject, new NestedObjectRulesProvider())
+                .For(rootObject)
+                .Validate();
+
+            result.ErrorMessages.ShouldNotContain("One");
+            result.ErrorMessages.ShouldContain("Two");
+            result.ErrorMessages.ShouldContain("Three");
+        }
+
+        [Fact]
+        public void Validation_Succeeds_When_Valid_NestedObject_Is_Given()
+        {
+            var rootObject = RootObject.GetValid();
+            
+            var result = ValitRules<RootObject>
+                .Create()
+                .Ensure(m => m.StringValue, _=>_
+                    .Required())
+                .Ensure(m => m.NestedObject, new NestedObjectRulesProvider())
+                .For(rootObject)
+                .Validate();
+
+            Assert.True(result.Succeeded);
+        }
+
+#region  ARRANGE
+        class RootObject
+        {
+            public string StringValue { get; set; }
+            public NestedObject NestedObject { get; set; }
+
+            public static RootObject GetInvalid()
+                => new RootObject
+                {
+                    StringValue = "Text",
+                    NestedObject = new NestedObject
+                    {
+                        NumericValue = 20,
+                        StringValue = null
+                    }
+                };
+
+            public static RootObject GetValid()
+                => new RootObject
+                {
+                    StringValue = "Text",
+                    NestedObject = new NestedObject
+                    {
+                        NumericValue = 20,
+                        StringValue = "someemail@test.com"
+                    }
+                };
+        }   
+
+        class NestedObject
+        {
+            public ushort NumericValue { get; set;}
+            public string StringValue { get; set;}
+        }
+
+		class NestedObjectRulesProvider : IValitRulesProvider<NestedObject>
+		{
+			public IEnumerable<IValitRule<NestedObject>> GetRules()
+                => ValitRules<NestedObject>
+                        .Create()
+                        .Ensure(m => m.NumericValue, _=>_
+                            .IsGreaterThan(10)
+                                .WithMessage("One"))
+                        .Ensure(m => m.StringValue, _=>_
+                            .Required()
+                                .WithMessage("Two")
+                            .Email()
+                                .WithMessage("Three"))
+                        .GetAllRules();
+		}
+    }
+#endregion
+}

--- a/tests/Valit.Tests/ValitRulesProvider/Valitator_Tests.cs
+++ b/tests/Valit.Tests/ValitRulesProvider/Valitator_Tests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+
+namespace Valit.Tests.ValitRulesProvider
+{
+    public class Valitator_Tests
+    {
+        [Fact]
+        public void CreateValitator_Throws_When_Null_ValitRulesProvider_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                var valitator = ((IValitRulesProvider<Model>)null).CreateValitator();
+            });
+            
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void Created_Valitator_Properly_Handles_Complete_Strategy()
+        {
+            var valitator = new ModelRulesProvider().CreateValitator();            
+            var result = valitator.Validate(_model);
+
+            Assert.False(result.Succeeded);
+            result.ErrorMessages.ShouldContain("One");
+            result.ErrorMessages.ShouldNotContain("Two");
+            result.ErrorMessages.ShouldContain("Three");
+        }
+
+        [Fact]
+        public void Created_Valitator_Properly_Handles_FailFast_Strategy()
+        {
+            var valitator = new ModelRulesProvider().CreateValitator();            
+            var result = valitator.Validate(_model, new FailFastValitStrategy());
+
+            Assert.False(result.Succeeded);
+            result.ErrorMessages.ShouldContain("One");
+            result.ErrorMessages.ShouldNotContain("Two");
+            result.ErrorMessages.ShouldNotContain("Three");
+        }
+
+
+#region  ARRANGE 
+
+        class Model
+        {
+            public ushort NumericValue { get; set; }
+            public string StringValue { get; set; }
+        }
+
+		class ModelRulesProvider : IValitRulesProvider<Model>
+		{
+			public IEnumerable<IValitRule<Model>> GetRules()
+                => ValitRules<Model>
+                        .Create()
+                        .Ensure(m => m.NumericValue, _=>_
+                            .IsGreaterThan(10)
+                                .WithMessage("One"))
+                        .Ensure(m => m.StringValue, _=>_
+                            .Required()
+                                .WithMessage("Two")
+                            .Email()
+                                .WithMessage("Three"))
+                        .GetAllRules();
+		}
+
+        private readonly Model _model;
+
+        public Valitator_Tests()
+        {
+            _model = new Model 
+            {
+                NumericValue = 3,
+                StringValue = "Text"
+            };
+        }
+    }
+#endregion 
+    
+}


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. 112 ( #112 ) 

I changed my first idea about validating nested objects. Whole concept is now based on new type of provider - ``IValitRulesProvider<TObject>``. Type which implements this interface is responsible for providing collection of ``IValitRule<TObject>`` objects. This gives us a lot of flexibility since we can create very complex validations using composition. As a feature, I added also extension method which transforms given provider into validator of type ``IValtator<TObject>`` with single method - ``Validate(TObject @object, IValitStrategy strategy``). Of course you can find our internal implementation of that interface as well.

Examples can be found inside tests ;)

Hopefully, you'll like it! 

# Changes
- Added ``IValitRulesProvider<TObject>`` interface
- Added ``NestedObjectValitRule`` internal class which gets rules of given nested object
- Added ``Ensure()`` method overload which accepts valit rules provider as a second parameter
- Added `` IValitator<TObject>`` interface
- Added ``Valitator<TObject>`` internal class as default implementaion of the above interface
- Added ``CreateValitator()`` etension method for valit rules provider
- Added unit tests
- Added missing null checking in couple places