### PR TITLE
Fix typo 'Privider'

### DIFF
--- a/tests/Valit.Tests/MessageProvider/CustomMessageProvider_Tests.cs
+++ b/tests/Valit.Tests/MessageProvider/CustomMessageProvider_Tests.cs
@@ -30,12 +30,19 @@ namespace Valit.Tests.MessageProvider
             result.ErrorMessages.ShouldContain("Three");
         }
 
-        Model _model => new Model();
+#region ARRANGE
+        public CustomMessageProvider_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
 
         class Model
         {
             public string Value => "This text has 28 characters!";
         }
+#endregion
     }
 
     class CustomMessageProvider : IValitMessageProvider<int>

--- a/tests/Valit.Tests/MessageProvider/CustomMessageProvider_Tests.cs
+++ b/tests/Valit.Tests/MessageProvider/CustomMessageProvider_Tests.cs
@@ -4,14 +4,14 @@ using Shouldly;
 
 namespace Valit.Tests.MessageProvider
 {
-    public class CustomMessagePrivider_Tests
+    public class CustomMessageProvider_Tests
     {
         [Fact]
-        public void CustomMessagePrivider_Adds_Proper_Messages()
+        public void CustomMessageProvider_Adds_Proper_Messages()
         {
             var result = ValitRules<Model>
                 .Create()
-                .WithMessageProvider(new CustomMessagePrivider())
+                .WithMessageProvider(new CustomMessageProvider())
                 .Ensure(m => m.Value, _ => _
                     .MaxLength(10)
                     .WithMessageKey(1)
@@ -38,7 +38,7 @@ namespace Valit.Tests.MessageProvider
         }
     }
 
-    class CustomMessagePrivider : IValitMessageProvider<int>
+    class CustomMessageProvider : IValitMessageProvider<int>
     {
         private IDictionary<int, string> _messages =
             new Dictionary<int, string>


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. / - this has no issue.

# Changes
- Fix typo `Privider` to `Provider`
- Create the testing model similar like the other tests