### PR TITLE
Remove spaces in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,8 +297,8 @@ __pycache__/
 *.pyc
 
 # Cake - Uncomment if you are using it
- tools/**
- !tools/packages.config
+tools/**
+!tools/packages.config
 
 # Tabs Studio
 *.tss
@@ -312,5 +312,5 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 
-# diff 
-*.orig 
+# diff
+*.orig

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.23.0" />
+</packages>


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. #122 
Small change to `.gitignore` because right now every file from `./tools` will be commited when someone builds the project via the build scripts.

# Changes
- Removed spaces 
- Ran the cake build to add `packages.config`
