### PR TITLE
Added CreateValitator extension method for IValitRules

### DIFF
--- a/src/Valit/Validators/Valitator.cs
+++ b/src/Valit/Validators/Valitator.cs
@@ -8,7 +8,14 @@ namespace Valit.Validators
 
         internal Valitator(IValitRulesProvider<TObject> valitRulesProvider)
         {
-            _strategyPicker = CreateStrategyPicker(valitRulesProvider);
+            var rules = valitRulesProvider.GetRules();
+            _strategyPicker = ValitRules<TObject>.Create(rules);
+        }
+
+        internal Valitator(IValitRules<TObject> valitRules)
+        {
+            var rules = valitRules.GetAllRules();
+            _strategyPicker = ValitRules<TObject>.Create(rules);
         }
 
         IValitResult IValitator<TObject>.Validate(TObject @object, IValitStrategy strategy)
@@ -19,12 +26,6 @@ namespace Valit.Validators
                 .WithStrategy(selectedStrategy)
                 .For(@object)
                 .Validate();
-        }
-
-        private IValitRulesStrategyPicker<TObject> CreateStrategyPicker(IValitRulesProvider<TObject> valitRulesProvider)
-        {
-            var rules = valitRulesProvider.GetRules();
-            return ValitRules<TObject>.Create(rules);
         }
     }
 }

--- a/src/Valit/ValitRules.cs
+++ b/src/Valit/ValitRules.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Valit.Exceptions;
@@ -46,7 +46,7 @@ namespace Valit
             selector.ThrowIfNull();
             ruleFunc.ThrowIfNull();
 
-            AddEnsureRulesAccessors(selector, ruleFunc);
+            AddEnsureRules(selector, ruleFunc);
             return this;
         }
 
@@ -139,7 +139,7 @@ namespace Valit
             return result;
         }
 
-        private void AddEnsureRulesAccessors<TProperty>(Func<TObject,TProperty> propertySelector, Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> ruleFunc)
+        private void AddEnsureRules<TProperty>(Func<TObject,TProperty> propertySelector, Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> ruleFunc)
         {
             var lastEnsureRule = ruleFunc(new ValitRule<TObject, TProperty>(propertySelector, _messageProvider));
             var ensureRules = lastEnsureRule.GetAllEnsureRules();

--- a/src/Valit/ValitatorExtensions.cs
+++ b/src/Valit/ValitatorExtensions.cs
@@ -10,5 +10,11 @@ namespace Valit
             valitRulesProvider.ThrowIfNull();
             return new Valitator<TObject>(valitRulesProvider);
         }
+
+        public static IValitator<TObject> CreateValitator<TObject>(this IValitRules<TObject> valitRules) where TObject : class
+        {
+            valitRules.ThrowIfNull();
+            return new Valitator<TObject>(valitRules);
+        }        
     }
 }

--- a/tests/Valit.Tests/Valitator/Valitator_MessageProvider_Tests.cs
+++ b/tests/Valit.Tests/Valitator/Valitator_MessageProvider_Tests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+
+namespace Valit.Tests.Valitator
+{
+    public class Valitator_MessageProvider_Tests
+    {
+        [Fact]
+        public void CreateValitator_Throws_When_Null_ValitRulesProvider_Is_Given()
+        {
+            var exception = Record.Exception(() => {
+                var valitator = ((IValitRulesProvider<Model>)null).CreateValitator();
+            });
+
+            exception.ShouldBeOfType(typeof(ValitException));
+        }
+
+        [Fact]
+        public void Created_Valitator_Properly_Handles_Complete_Strategy()
+        {
+            var valitator = new ModelRulesProvider().CreateValitator();
+            var result = valitator.Validate(_model);
+
+            Assert.False(result.Succeeded);
+            result.ErrorMessages.ShouldContain("One");
+            result.ErrorMessages.ShouldNotContain("Two");
+            result.ErrorMessages.ShouldContain("Three");
+        }
+
+        [Fact]
+        public void Created_Valitator_Properly_Handles_FailFast_Strategy()
+        {
+            var valitator = new ModelRulesProvider().CreateValitator();
+            var result = valitator.Validate(_model, new FailFastValitStrategy());
+
+            Assert.False(result.Succeeded);
+            result.ErrorMessages.ShouldContain("One");
+            result.ErrorMessages.ShouldNotContain("Two");
+            result.ErrorMessages.ShouldNotContain("Three");
+        }
+
+
+#region  ARRANGE
+
+        class Model
+        {
+            public ushort NumericValue { get; set; }
+            public string StringValue { get; set; }
+        }
+
+        class ModelRulesProvider : IValitRulesProvider<Model>
+        {
+            public IEnumerable<IValitRule<Model>> GetRules()
+                => ValitRules<Model>
+                        .Create()
+                        .Ensure(m => m.NumericValue, _=>_
+                            .IsGreaterThan(10)
+                                .WithMessage("One"))
+                        .Ensure(m => m.StringValue, _=>_
+                            .Required()
+                                .WithMessage("Two")
+                            .Email()
+                                .WithMessage("Three"))
+                        .GetAllRules();
+        }
+
+        private readonly Model _model;
+
+        public Valitator_MessageProvider_Tests()
+        {
+            _model = new Model
+            {
+                NumericValue = 3,
+                StringValue = "Text"
+            };
+        }
+    }
+#endregion
+
+}

--- a/tests/Valit.Tests/Valitator/Valitator_ValitRules_Tests.cs
+++ b/tests/Valit.Tests/Valitator/Valitator_ValitRules_Tests.cs
@@ -4,13 +4,13 @@ using Xunit;
 
 namespace Valit.Tests.Valitator
 {
-    public class Valitator_Tests
+    public class Valitator_ValitRules_Tests
     {
         [Fact]
         public void CreateValitator_Throws_When_Null_ValitRulesProvider_Is_Given()
         {
             var exception = Record.Exception(() => {
-                var valitator = ((IValitRulesProvider<Model>)null).CreateValitator();
+                var valitator = ((IValitRules<Model>)null).CreateValitator();
             });
 
             exception.ShouldBeOfType(typeof(ValitException));
@@ -19,7 +19,7 @@ namespace Valit.Tests.Valitator
         [Fact]
         public void Created_Valitator_Properly_Handles_Complete_Strategy()
         {
-            var valitator = new ModelRulesProvider().CreateValitator();
+            var valitator = _valitRules.CreateValitator();
             var result = valitator.Validate(_model);
 
             Assert.False(result.Succeeded);
@@ -31,7 +31,7 @@ namespace Valit.Tests.Valitator
         [Fact]
         public void Created_Valitator_Properly_Handles_FailFast_Strategy()
         {
-            var valitator = new ModelRulesProvider().CreateValitator();
+            var valitator = _valitRules.CreateValitator();
             var result = valitator.Validate(_model, new FailFastValitStrategy());
 
             Assert.False(result.Succeeded);
@@ -49,31 +49,27 @@ namespace Valit.Tests.Valitator
             public string StringValue { get; set; }
         }
 
-        class ModelRulesProvider : IValitRulesProvider<Model>
-        {
-            public IEnumerable<IValitRule<Model>> GetRules()
-                => ValitRules<Model>
-                        .Create()
-                        .Ensure(m => m.NumericValue, _=>_
-                            .IsGreaterThan(10)
-                                .WithMessage("One"))
-                        .Ensure(m => m.StringValue, _=>_
-                            .Required()
-                                .WithMessage("Two")
-                            .Email()
-                                .WithMessage("Three"))
-                        .GetAllRules();
-        }
-
         private readonly Model _model;
+        private readonly IValitRules<Model> _valitRules;
 
-        public Valitator_Tests()
+        public Valitator_ValitRules_Tests()
         {
             _model = new Model
             {
                 NumericValue = 3,
                 StringValue = "Text"
             };
+
+            _valitRules = ValitRules<Model>
+                .Create()
+                .Ensure(m => m.NumericValue, _=>_
+                    .IsGreaterThan(10)
+                        .WithMessage("One"))
+                .Ensure(m => m.StringValue, _=>_
+                    .Required()
+                        .WithMessage("Two")
+                    .Email()
+                        .WithMessage("Three"));
         }
     }
 #endregion


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. #129 

# Changes
- Added contructor overload for ``Valitator``
- Added ``CreateValitator()`` extenions method for ``IValitRules<TObject>``
- Added unit tests
- Renamed ``AddEnsureRulesAccessors`` to ``AddEnsureRules``
- Changed name of valitator tests using message provider