### PR TITLE
Rewrite tests with Shouldly

### DIFF
--- a/tests/Valit.Tests/Boolean/Boolean_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/Boolean/Boolean_IsEqual_To_Tests.cs
@@ -66,7 +66,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Boolean/Boolean_IsFalse_Tests.cs
+++ b/tests/Valit.Tests/Boolean/Boolean_IsFalse_Tests.cs
@@ -42,7 +42,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -57,7 +57,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
 

--- a/tests/Valit.Tests/Boolean/Boolean_IsTrue_Tests.cs
+++ b/tests/Valit.Tests/Boolean/Boolean_IsTrue_Tests.cs
@@ -42,7 +42,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -57,7 +57,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
 

--- a/tests/Valit.Tests/Boolean/Boolean_Required_Tests.cs
+++ b/tests/Valit.Tests/Boolean/Boolean_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.Boolean
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Byte/Byte_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/Byte/Byte_IsEqual_To_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsEqualTo_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsEqualTo(1);
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsEqualTo_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsEqualTo((byte?)1);
             });
@@ -30,7 +32,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsEqualTo_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsEqualTo(1);
             });
@@ -41,7 +44,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsEqualTo_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsEqualTo((byte?)1);
             });
@@ -54,33 +58,33 @@ namespace Valit.Tests.Byte
         [InlineData(10, true)]
         [InlineData(9, false)]
         [InlineData(11, false)]
-        public void Byte_IsEqualTo_Returns_Proper_Results_For_Not_Nullable_Values(byte value,  bool expected)
+        public void Byte_IsEqualTo_Returns_Proper_Results_For_Not_Nullable_Values(byte value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
-        [InlineData((byte) 10, true)]
-        [InlineData((byte) 9, false)]
-        [InlineData((byte) 11, false)]
+        [InlineData((byte)10, true)]
+        [InlineData((byte)9, false)]
+        [InlineData((byte)11, false)]
         [InlineData(null, false)]
-        public void Byte_IsEqualTo_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(byte? value,  bool expected)
+        public void Byte_IsEqualTo_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(byte? value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -88,38 +92,38 @@ namespace Valit.Tests.Byte
         [InlineData(false, 9, false)]
         [InlineData(false, 11, false)]
         [InlineData(true, 10, false)]
-        public void Byte_IsEqualTo_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, byte value,  bool expected)
+        public void Byte_IsEqualTo_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, byte value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
-        [InlineData(false, (byte) 10, true)]
-        [InlineData(false, (byte) 9, false)]
-        [InlineData(false, (byte) 11, false)]
+        [InlineData(false, (byte)10, true)]
+        [InlineData(false, (byte)9, false)]
+        [InlineData(false, (byte)11, false)]
         [InlineData(false, null, false)]
-        [InlineData(true, (byte) 10, false)]
+        [InlineData(true, (byte)10, false)]
         [InlineData(true, null, false)]
-        public void Byte_IsEqualTo_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, byte? value,  bool expected)
+        public void Byte_IsEqualTo_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, byte? value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Byte_IsEqualTo_Tests()
         {
             _model = new Model();
@@ -133,6 +137,6 @@ namespace Valit.Tests.Byte
             public byte? NullableValue => 10;
             public byte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Byte/Byte_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Byte/Byte_IsGreaterThanOrEqualTo_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsGreaterThanOrEqualTo_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsGreaterThanOrEqualTo(1);
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsGreaterThanOrEqualTo_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsGreaterThanOrEqualTo((byte?)1);
             });
@@ -30,7 +32,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsGreaterThanOrEqualTo_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsGreaterThanOrEqualTo(1);
             });
@@ -41,7 +44,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsGreaterThanOrEqualTo_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsGreaterThanOrEqualTo((byte?)1);
             });
@@ -54,33 +58,33 @@ namespace Valit.Tests.Byte
         [InlineData(9, true)]
         [InlineData(10, true)]
         [InlineData(11, false)]
-        public void Byte_IsGreaterThanOrEqualTo_Returns_Proper_Results_For_Not_Nullable_Values(byte value,  bool expected)
+        public void Byte_IsGreaterThanOrEqualTo_Returns_Proper_Results_For_Not_Nullable_Values(byte value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsGreaterThanOrEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
-        [InlineData((byte) 9, true)]
-        [InlineData((byte) 10, true)]
-        [InlineData((byte) 11, false)]
+        [InlineData((byte)9, true)]
+        [InlineData((byte)10, true)]
+        [InlineData((byte)11, false)]
         [InlineData(null, false)]
-        public void Byte_IsGreaterThanOrEqualTo_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(byte? value,  bool expected)
+        public void Byte_IsGreaterThanOrEqualTo_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(byte? value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsGreaterThanOrEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -88,38 +92,38 @@ namespace Valit.Tests.Byte
         [InlineData(false, 10, true)]
         [InlineData(false, 11, false)]
         [InlineData(true, 9, false)]
-        public void Byte_IsGreaterThanOrEqualTo_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, byte value,  bool expected)
+        public void Byte_IsGreaterThanOrEqualTo_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, byte value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsGreaterThanOrEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
-        [InlineData(false, (byte) 9, true)]
-        [InlineData(false, (byte) 10, true)]
-        [InlineData(false, (byte) 11, false)]
+        [InlineData(false, (byte)9, true)]
+        [InlineData(false, (byte)10, true)]
+        [InlineData(false, (byte)11, false)]
         [InlineData(false, null, false)]
-        [InlineData(true, (byte) 9, false)]
+        [InlineData(true, (byte)9, false)]
         [InlineData(true, null, false)]
-        public void Byte_IsGreaterThanOrEqualTo_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, byte? value,  bool expected)
+        public void Byte_IsGreaterThanOrEqualTo_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, byte? value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsGreaterThanOrEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Byte_IsGreaterThanOrEqualTo_Tests()
         {
             _model = new Model();
@@ -133,6 +137,6 @@ namespace Valit.Tests.Byte
             public byte? NullableValue => 10;
             public byte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Byte/Byte_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Byte/Byte_IsGreaterThan_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsGreaterThan_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsGreaterThan(1);
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsGreaterThan_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsGreaterThan((byte?)1);
             });
@@ -31,7 +33,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsGreaterThan_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsGreaterThan(1);
             });
@@ -42,7 +45,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsGreaterThan_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsGreaterThan((byte?)1);
             });
@@ -55,33 +59,33 @@ namespace Valit.Tests.Byte
         [InlineData(9, true)]
         [InlineData(10, false)]
         [InlineData(11, false)]
-        public void Byte_IsGreaterThan_Returns_Proper_Results_For_Not_Nullable_Values(byte value,  bool expected)
+        public void Byte_IsGreaterThan_Returns_Proper_Results_For_Not_Nullable_Values(byte value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsGreaterThan(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
-        [InlineData((byte) 9, true)]
-        [InlineData((byte) 10, false)]
-        [InlineData((byte) 11, false)]
+        [InlineData((byte)9, true)]
+        [InlineData((byte)10, false)]
+        [InlineData((byte)11, false)]
         [InlineData(null, false)]
-        public void Byte_IsGreaterThan_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(byte? value,  bool expected)
+        public void Byte_IsGreaterThan_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(byte? value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsGreaterThan(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -89,38 +93,38 @@ namespace Valit.Tests.Byte
         [InlineData(false, 10, false)]
         [InlineData(false, 11, false)]
         [InlineData(true, 9, false)]
-        public void Byte_IsGreaterThan_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, byte value,  bool expected)
+        public void Byte_IsGreaterThan_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, byte value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsGreaterThan(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
-        [InlineData(false, (byte) 9, true)]
-        [InlineData(false, (byte) 10, false)]
-        [InlineData(false, (byte) 11, false)]
+        [InlineData(false, (byte)9, true)]
+        [InlineData(false, (byte)10, false)]
+        [InlineData(false, (byte)11, false)]
         [InlineData(false, null, false)]
-        [InlineData(true, (byte) 9, false)]
+        [InlineData(true, (byte)9, false)]
         [InlineData(true, null, false)]
-        public void Byte_IsGreaterThan_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, byte? value,  bool expected)
+        public void Byte_IsGreaterThan_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, byte? value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsGreaterThan(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Byte_IsGreaterThan_Tests()
         {
             _model = new Model();
@@ -134,6 +138,6 @@ namespace Valit.Tests.Byte
             public byte? NullableValue => 10;
             public byte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Byte/Byte_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Byte/Byte_IsLessThanOrEqualTo_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsLessThanOrEqualTo_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsLessThanOrEqualTo(1);
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsLessThanOrEqualTo_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsLessThanOrEqualTo((byte?)1);
             });
@@ -30,7 +32,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsLessThanOrEqualTo_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsLessThanOrEqualTo(1);
             });
@@ -41,7 +44,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsLessThanOrEqualTo_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsLessThanOrEqualTo((byte?)1);
             });
@@ -54,33 +58,33 @@ namespace Valit.Tests.Byte
         [InlineData(11, true)]
         [InlineData(10, true)]
         [InlineData(9, false)]
-        public void Byte_IsLessThanOrEqualTo_Returns_Proper_Results_For_Not_Nullable_Values(byte value,  bool expected)
+        public void Byte_IsLessThanOrEqualTo_Returns_Proper_Results_For_Not_Nullable_Values(byte value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsLessThanOrEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
-        [InlineData((byte) 11, true)]
-        [InlineData((byte) 10, true)]
-        [InlineData((byte) 9, false)]
+        [InlineData((byte)11, true)]
+        [InlineData((byte)10, true)]
+        [InlineData((byte)9, false)]
         [InlineData(null, false)]
-        public void Byte_IsLessThanOrEqualTo_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(byte? value,  bool expected)
+        public void Byte_IsLessThanOrEqualTo_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(byte? value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsLessThanOrEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -88,38 +92,38 @@ namespace Valit.Tests.Byte
         [InlineData(false, 10, true)]
         [InlineData(false, 9, false)]
         [InlineData(true, 11, false)]
-        public void Byte_IsLessThanOrEqualTo_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, byte value,  bool expected)
+        public void Byte_IsLessThanOrEqualTo_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, byte value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsLessThanOrEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
-        [InlineData(false, (byte) 11, true)]
-        [InlineData(false, (byte) 10, true)]
-        [InlineData(false, (byte) 9, false)]
+        [InlineData(false, (byte)11, true)]
+        [InlineData(false, (byte)10, true)]
+        [InlineData(false, (byte)9, false)]
         [InlineData(false, null, false)]
-        [InlineData(true, (byte) 11, false)]
+        [InlineData(true, (byte)11, false)]
         [InlineData(true, null, false)]
-        public void Byte_IsLessThanOrEqualTo_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, byte? value,  bool expected)
+        public void Byte_IsLessThanOrEqualTo_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, byte? value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsLessThanOrEqualTo(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Byte_IsLessThanOrEqualTo_Tests()
         {
             _model = new Model();
@@ -133,6 +137,6 @@ namespace Valit.Tests.Byte
             public byte? NullableValue => 10;
             public byte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Byte/Byte_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Byte/Byte_IsLessThan_Tests.cs
@@ -67,7 +67,7 @@ namespace Valit.Tests.Byte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Valit.Tests.Byte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace Valit.Tests.Byte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -120,7 +120,7 @@ namespace Valit.Tests.Byte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Byte/Byte_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Byte/Byte_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.Byte
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Byte_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Byte_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Byte_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Byte_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.Byte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Byte_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.Byte
             public byte? NullableZeroValue => 0;
             public byte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Byte/Byte_Required_Tests.cs
+++ b/tests/Valit.Tests/Byte/Byte_Required_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Byte
         [Fact]
         public void Byte_Required_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, byte?>)null)
                     .Required();
             });
@@ -21,19 +22,19 @@ namespace Valit.Tests.Byte
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Byte_Required_Returns_Proper_Results_For_Nullable_Value(bool useNullValue,  bool expected)
+        public void Byte_Required_Returns_Proper_Results_For_Nullable_Value(bool useNullValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .Required())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Byte_Required_Tests()
         {
             _model = new Model();
@@ -49,6 +50,6 @@ namespace Valit.Tests.Byte
             public byte? NullableZeroValue => 0;
             public byte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Collection/Primitive_Property_Collection_Validation_Tests.cs
+++ b/tests/Valit.Tests/Collection/Primitive_Property_Collection_Validation_Tests.cs
@@ -12,10 +12,11 @@ namespace Valit.Tests.Collection
         [Fact]
         public void EnsureFor_Throws_When_Null_RuleFunc_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ValitRules<Model>
                     .Create()
-                    .EnsureFor(m => m.InvalidValuesCollection, (Func<IValitRule<Model,string>,IValitRule<Model,string>>)null);
+                    .EnsureFor(m => m.InvalidValuesCollection, (Func<IValitRule<Model, string>, IValitRule<Model, string>>)null);
             });
 
             exception.ShouldBeOfType(typeof(ValitException));
@@ -26,7 +27,7 @@ namespace Valit.Tests.Collection
         {
             var result = ValitRules<Model>
                 .Create()
-                .EnsureFor(m => m.InvalidValuesCollection, _=>_
+                .EnsureFor(m => m.InvalidValuesCollection, _ => _
                     .Required()
                         .WithMessage("One")
                     .Email()
@@ -34,7 +35,7 @@ namespace Valit.Tests.Collection
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
             result.ErrorMessages.Count(m => m == "One").ShouldBe(1);
             result.ErrorMessages.Count(m => m == "Two").ShouldBe(3);
         }
@@ -45,7 +46,7 @@ namespace Valit.Tests.Collection
             var result = ValitRules<Model>
                 .Create()
                 .WithStrategy(picker => picker.FailFast)
-                .EnsureFor(m => m.InvalidValuesCollection, _=>_
+                .EnsureFor(m => m.InvalidValuesCollection, _ => _
                     .Required()
                         .WithMessage("One")
                     .Email()
@@ -53,7 +54,7 @@ namespace Valit.Tests.Collection
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
             result.ErrorMessages.Count().ShouldBe(1);
             result.ErrorMessages.First().ShouldBe("Two");
         }
@@ -63,7 +64,7 @@ namespace Valit.Tests.Collection
         {
             var result = ValitRules<Model>
                 .Create()
-                .EnsureFor(m => m.ValidValuesCollection, _=>_
+                .EnsureFor(m => m.ValidValuesCollection, _ => _
                     .Required()
                         .WithMessage("One")
                     .Email()
@@ -71,7 +72,7 @@ namespace Valit.Tests.Collection
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -80,7 +81,7 @@ namespace Valit.Tests.Collection
             var result = ValitRules<Model>
                 .Create()
                 .WithStrategy(picker => picker.FailFast)
-                .EnsureFor(m => m.ValidValuesCollection, _=>_
+                .EnsureFor(m => m.ValidValuesCollection, _ => _
                     .Required()
                         .WithMessage("One")
                     .Email()
@@ -88,11 +89,11 @@ namespace Valit.Tests.Collection
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
 
-#region ARRANGE
+        #region ARRANGE
         private readonly Model _model;
 
         public Primitive_Property_Collection_Validation_Tests()
@@ -116,6 +117,6 @@ namespace Valit.Tests.Collection
                 "another.correct.email@test.com"
             };
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsAfterNow_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsAfterNow_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfterNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsAfterNow();
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfterNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
                     .IsAfterNow();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.AfterNowValue, _=>_
+                .Ensure(m => m.AfterNowValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.BeforeNowValue, _=>_
+                .Ensure(m => m.BeforeNowValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,12 +62,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableAfterNowValue, _=>_
+                .Ensure(m => m.NullableAfterNowValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -73,12 +75,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                .Ensure(m => m.NullableBeforeNowValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTimeOffset_IsAfterNow_Tests()
         {
             _model = new Model();
@@ -110,6 +112,6 @@ namespace Valit.Tests.DateTimeOffset_
             public DateTimeOffset? NullableAfterNowValue => DateTimeOffset.Now.AddDays(1);
             public DateTimeOffset? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsAfterOrSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsAfterOrSameAs_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfterOrSameAs_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsAfterOrSameAs(DateTimeOffset.Now);
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfterOrSameAs_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsAfterOrSameAs((DateTimeOffset?)DateTimeOffset.Now);
             });
@@ -32,7 +34,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfterOrSameAs_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
                     .IsAfterOrSameAs(DateTimeOffset.Now);
             });
@@ -43,9 +46,10 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfterOrSameAs_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
-                    .IsAfterOrSameAs((DateTimeOffset?) DateTimeOffset.Now);
+                    .IsAfterOrSameAs((DateTimeOffset?)DateTimeOffset.Now);
             });
 
             exception.ShouldBeOfType(typeof(ValitException));
@@ -55,18 +59,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData("2017-06-09", true)]
         [InlineData("2017-06-10", true)]
         [InlineData("2017-06-11", false)]
-        public void DateTimeOffset_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Values(string stringValue,  bool expected)
+        public void DateTimeOffset_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Values(string stringValue, bool expected)
         {
             var value = stringValue.AsDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsAfterOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -74,18 +78,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData("2017-06-10", true)]
         [InlineData("2017-06-11", false)]
         [InlineData(null, false)]
-        public void DateTimeOffset_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        public void DateTimeOffset_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue, bool expected)
         {
             DateTimeOffset? value = stringValue.AsNullableDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsAfterOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -93,18 +97,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData(false, "2017-06-10", true)]
         [InlineData(false, "2017-06-11", false)]
         [InlineData(true, "2017-06-09", false)]
-        public void DateTimeOffset_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, string stringValue,  bool expected)
+        public void DateTimeOffset_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, string stringValue, bool expected)
         {
             var value = stringValue.AsDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsAfterOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -114,21 +118,21 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData(false, null, false)]
         [InlineData(true, "2017-06-09", false)]
         [InlineData(true, null, false)]
-        public void DateTimeOffset_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        public void DateTimeOffset_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue, bool expected)
         {
             DateTimeOffset? value = stringValue.AsNullableDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsAfterOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTimeOffset_IsAfterOrSameAs_Tests()
         {
             _model = new Model();
@@ -142,6 +146,6 @@ namespace Valit.Tests.DateTimeOffset_
             public DateTimeOffset? NullableValue => new DateTimeOffset(new DateTime(2017, 6, 10));
             public DateTimeOffset? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsAfterUtcNow_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsAfterUtcNow_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfterUtcNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsAfterUtcNow();
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfterUtcNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
                     .IsAfterUtcNow();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.AfterNowValue, _=>_
+                .Ensure(m => m.AfterNowValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.BeforeNowValue, _=>_
+                .Ensure(m => m.BeforeNowValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,12 +62,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableAfterNowValue, _=>_
+                .Ensure(m => m.NullableAfterNowValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -73,12 +75,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                .Ensure(m => m.NullableBeforeNowValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTimeOffset_IsAfterUtcNow_Tests()
         {
             _model = new Model();
@@ -110,6 +112,6 @@ namespace Valit.Tests.DateTimeOffset_
             public DateTimeOffset? NullableAfterNowValue => DateTimeOffset.UtcNow.AddDays(1);
             public DateTimeOffset? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsAfter_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsAfter_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfter_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsAfter(DateTimeOffset.Now);
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfter_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsAfter((DateTimeOffset?)DateTimeOffset.Now);
             });
@@ -32,7 +34,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfter_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
                     .IsAfter(DateTimeOffset.Now);
             });
@@ -43,9 +46,10 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsAfter_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
-                    .IsAfter((DateTimeOffset?) DateTimeOffset.Now);
+                    .IsAfter((DateTimeOffset?)DateTimeOffset.Now);
             });
 
             exception.ShouldBeOfType(typeof(ValitException));
@@ -55,18 +59,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData("2017-06-09", true)]
         [InlineData("2017-06-10", false)]
         [InlineData("2017-06-11", false)]
-        public void DateTimeOffset_IsAfter_Returns_Proper_Results_For_Not_Nullable_Values(string stringValue,  bool expected)
+        public void DateTimeOffset_IsAfter_Returns_Proper_Results_For_Not_Nullable_Values(string stringValue, bool expected)
         {
             var value = stringValue.AsDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsAfter(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -74,18 +78,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData("2017-06-10", false)]
         [InlineData("2017-06-11", false)]
         [InlineData(null, false)]
-        public void DateTimeOffset_IsAfter_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        public void DateTimeOffset_IsAfter_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue, bool expected)
         {
             DateTimeOffset? value = stringValue.AsNullableDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsAfter(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -93,18 +97,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData(false, "2017-06-10", false)]
         [InlineData(false, "2017-06-11", false)]
         [InlineData(true, "2017-06-09", false)]
-        public void DateTimeOffset_IsAfter_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, string stringValue,  bool expected)
+        public void DateTimeOffset_IsAfter_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, string stringValue, bool expected)
         {
             var value = stringValue.AsDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsAfter(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -114,21 +118,21 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData(false, null, false)]
         [InlineData(true, "2017-06-09", false)]
         [InlineData(true, null, false)]
-        public void DateTimeOffset_IsAfter_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        public void DateTimeOffset_IsAfter_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue, bool expected)
         {
             DateTimeOffset? value = stringValue.AsNullableDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsAfter(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTimeOffset_IsAfter_Tests()
         {
             _model = new Model();
@@ -142,6 +146,6 @@ namespace Valit.Tests.DateTimeOffset_
             public DateTimeOffset? NullableValue => new DateTimeOffset(new DateTime(2017, 6, 10));
             public DateTimeOffset? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsBeforeNow_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsBeforeNow_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsBeforeNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsBeforeNow();
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsBeforeNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
                     .IsBeforeNow();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.BeforeNowValue, _=>_
+                .Ensure(m => m.BeforeNowValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.AfterNowValue, _=>_
+                .Ensure(m => m.AfterNowValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,12 +62,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                .Ensure(m => m.NullableBeforeNowValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -73,12 +75,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableAfterNowValue, _=>_
+                .Ensure(m => m.NullableAfterNowValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTimeOffset_IsBeforeNow_Tests()
         {
             _model = new Model();
@@ -110,6 +112,6 @@ namespace Valit.Tests.DateTimeOffset_
             public DateTimeOffset? NullableAfterNowValue => DateTimeOffset.Now.AddDays(1);
             public DateTimeOffset? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsBeforeOrSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsBeforeOrSameAs_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsBeforeOrSameAs_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsBeforeOrSameAs(DateTimeOffset.Now);
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsBeforeOrSameAs_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsBeforeOrSameAs((DateTimeOffset?)DateTimeOffset.Now);
             });
@@ -32,7 +34,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsBeforeOrSameAs_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
                     .IsBeforeOrSameAs(DateTimeOffset.Now);
             });
@@ -43,9 +46,10 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsBeforeOrSameAs_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
-                    .IsBeforeOrSameAs((DateTimeOffset?) DateTimeOffset.Now);
+                    .IsBeforeOrSameAs((DateTimeOffset?)DateTimeOffset.Now);
             });
 
             exception.ShouldBeOfType(typeof(ValitException));
@@ -55,18 +59,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData("2017-06-11", true)]
         [InlineData("2017-06-10", true)]
         [InlineData("2017-06-09", false)]
-        public void DateTimeOffset_IsBeforeOrSameAs_Returns_Proper_Results_For_Not_Nullable_Values(string stringValue,  bool expected)
+        public void DateTimeOffset_IsBeforeOrSameAs_Returns_Proper_Results_For_Not_Nullable_Values(string stringValue, bool expected)
         {
             var value = stringValue.AsDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsBeforeOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -74,18 +78,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData("2017-06-10", true)]
         [InlineData("2017-06-09", false)]
         [InlineData(null, false)]
-        public void DateTimeOffset_IsBeforeOrSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        public void DateTimeOffset_IsBeforeOrSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue, bool expected)
         {
             DateTimeOffset? value = stringValue.AsNullableDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsBeforeOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -93,18 +97,18 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData(false, "2017-06-10", true)]
         [InlineData(false, "2017-06-09", false)]
         [InlineData(true, "2017-06-11", false)]
-        public void DateTimeOffset_IsBeforeOrSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, string stringValue,  bool expected)
+        public void DateTimeOffset_IsBeforeOrSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, string stringValue, bool expected)
         {
             var value = stringValue.AsDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsBeforeOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -114,21 +118,21 @@ namespace Valit.Tests.DateTimeOffset_
         [InlineData(false, null, false)]
         [InlineData(true, "2017-06-11", false)]
         [InlineData(true, null, false)]
-        public void DateTimeOffset_IsBeforeOrSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        public void DateTimeOffset_IsBeforeOrSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue, bool expected)
         {
             DateTimeOffset? value = stringValue.AsNullableDateTimeOffset();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsBeforeOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTimeOffset_IsBeforeOrSameAs_Tests()
         {
             _model = new Model();
@@ -142,6 +146,6 @@ namespace Valit.Tests.DateTimeOffset_
             public DateTimeOffset? NullableValue => new DateTimeOffset(new DateTime(2017, 6, 10));
             public DateTimeOffset? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsBeforeUtcNow_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsBeforeUtcNow_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsBeforeUtcNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset>)null)
                     .IsBeforeUtcNow();
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTimeOffset_
         [Fact]
         public void DateTimeOffset_IsBeforeUtcNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTimeOffset?>)null)
                     .IsBeforeUtcNow();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.BeforeNowValue, _=>_
+                .Ensure(m => m.BeforeNowValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.AfterNowValue, _=>_
+                .Ensure(m => m.AfterNowValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,12 +62,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                .Ensure(m => m.NullableBeforeNowValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -73,12 +75,12 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableAfterNowValue, _=>_
+                .Ensure(m => m.NullableAfterNowValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.DateTimeOffset_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTimeOffset_IsBeforeUtcNow_Tests()
         {
             _model = new Model();
@@ -110,6 +112,6 @@ namespace Valit.Tests.DateTimeOffset_
             public DateTimeOffset? NullableAfterNowValue => DateTimeOffset.UtcNow.AddDays(1);
             public DateTimeOffset? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsBefore_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsBefore_Tests.cs
@@ -66,7 +66,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -85,7 +85,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -104,7 +104,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -125,7 +125,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_IsSameAs_Tests.cs
@@ -66,7 +66,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -85,7 +85,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -104,7 +104,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -125,7 +125,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_Required_Tests.cs
+++ b/tests/Valit.Tests/DateTimeOffset_/DateTimeOffset_Required_Tests.cs
@@ -31,7 +31,7 @@ namespace Valit.Tests.DateTimeOffset_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/DateTime_/DateTime_IsAfterNow_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsAfterNow_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfterNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime>)null)
                     .IsAfterNow();
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfterNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime?>)null)
                     .IsAfterNow();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.AfterNowValue, _=>_
+                .Ensure(m => m.AfterNowValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.BeforeNowValue, _=>_
+                .Ensure(m => m.BeforeNowValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,12 +62,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableAfterNowValue, _=>_
+                .Ensure(m => m.NullableAfterNowValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -73,12 +75,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                .Ensure(m => m.NullableBeforeNowValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsAfterNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTime_IsAfterNow_Tests()
         {
             _model = new Model();
@@ -110,6 +112,6 @@ namespace Valit.Tests.DateTime_
             public DateTime? NullableAfterNowValue => DateTime.Now.AddDays(1);
             public DateTime? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTime_/DateTime_IsAfterOrSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsAfterOrSameAs_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfterOrSameAs_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime>)null)
                     .IsAfterOrSameAs(DateTime.Now);
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfterOrSameAs_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime>)null)
                     .IsAfterOrSameAs((DateTime?)DateTime.Now);
             });
@@ -32,7 +34,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfterOrSameAs_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime?>)null)
                     .IsAfterOrSameAs(DateTime.Now);
             });
@@ -43,9 +46,10 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfterOrSameAs_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime?>)null)
-                    .IsAfterOrSameAs((DateTime?) DateTime.Now);
+                    .IsAfterOrSameAs((DateTime?)DateTime.Now);
             });
 
             exception.ShouldBeOfType(typeof(ValitException));
@@ -55,16 +59,16 @@ namespace Valit.Tests.DateTime_
         [InlineData("2017-06-09", true)]
         [InlineData("2017-06-10", true)]
         [InlineData("2017-06-11", false)]
-        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value,  bool expected)
+        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsAfterOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -72,18 +76,18 @@ namespace Valit.Tests.DateTime_
         [InlineData("2017-06-10", true)]
         [InlineData("2017-06-11", false)]
         [InlineData(null, false)]
-        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue, bool expected)
         {
             DateTime? value = stringValue.AsNullableDateTime();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsAfterOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -91,16 +95,16 @@ namespace Valit.Tests.DateTime_
         [InlineData(false, "2017-06-10", true)]
         [InlineData(false, "2017-06-11", false)]
         [InlineData(true, "2017-06-09", false)]
-        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value,  bool expected)
+        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsAfterOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -110,21 +114,21 @@ namespace Valit.Tests.DateTime_
         [InlineData(false, null, false)]
         [InlineData(true, "2017-06-09", false)]
         [InlineData(true, null, false)]
-        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        public void DateTime_IsAfterOrSameAs_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue, bool expected)
         {
             DateTime? value = stringValue.AsNullableDateTime();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsAfterOrSameAs(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTime_IsAfterOrSameAs_Tests()
         {
             _model = new Model();
@@ -138,6 +142,6 @@ namespace Valit.Tests.DateTime_
             public DateTime? NullableValue => new DateTime(2017, 6, 10);
             public DateTime? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTime_/DateTime_IsAfterUtcNow_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsAfterUtcNow_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfterUtcNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime>)null)
                     .IsAfterUtcNow();
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfterUtcNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime?>)null)
                     .IsAfterUtcNow();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.AfterNowValue, _=>_
+                .Ensure(m => m.AfterNowValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.BeforeNowValue, _=>_
+                .Ensure(m => m.BeforeNowValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,12 +62,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableAfterNowValue, _=>_
+                .Ensure(m => m.NullableAfterNowValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -73,12 +75,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                .Ensure(m => m.NullableBeforeNowValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsAfterUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTime_IsAfterUtcNow_Tests()
         {
             _model = new Model();
@@ -110,6 +112,6 @@ namespace Valit.Tests.DateTime_
             public DateTime? NullableAfterNowValue => DateTime.UtcNow.AddDays(1);
             public DateTime? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTime_/DateTime_IsAfter_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsAfter_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfter_For_Not_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime>)null)
                     .IsAfter(DateTime.Now);
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfter_For_Not_Nullable_Value_And_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime>)null)
                     .IsAfter((DateTime?)DateTime.Now);
             });
@@ -32,7 +34,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfter_For_Nullable_Value_And_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime?>)null)
                     .IsAfter(DateTime.Now);
             });
@@ -43,9 +46,10 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsAfter_For_Nullable_Values_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime?>)null)
-                    .IsAfter((DateTime?) DateTime.Now);
+                    .IsAfter((DateTime?)DateTime.Now);
             });
 
             exception.ShouldBeOfType(typeof(ValitException));
@@ -55,16 +59,16 @@ namespace Valit.Tests.DateTime_
         [InlineData("2017-06-09", true)]
         [InlineData("2017-06-10", false)]
         [InlineData("2017-06-11", false)]
-        public void DateTime_IsAfter_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value,  bool expected)
+        public void DateTime_IsAfter_Returns_Proper_Results_For_Not_Nullable_Values(DateTime value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsAfter(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -72,18 +76,18 @@ namespace Valit.Tests.DateTime_
         [InlineData("2017-06-10", false)]
         [InlineData("2017-06-11", false)]
         [InlineData(null, false)]
-        public void DateTime_IsAfter_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue,  bool expected)
+        public void DateTime_IsAfter_Returns_Proper_Results_For_Not_Nullable_Value_And_Nullable_Value(string stringValue, bool expected)
         {
             DateTime? value = stringValue.AsNullableDateTime();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .IsAfter(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -91,16 +95,16 @@ namespace Valit.Tests.DateTime_
         [InlineData(false, "2017-06-10", false)]
         [InlineData(false, "2017-06-11", false)]
         [InlineData(true, "2017-06-09", false)]
-        public void DateTime_IsAfter_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value,  bool expected)
+        public void DateTime_IsAfter_Returns_Proper_Results_For_Nullable_Value_And_Not_Nullable_Value(bool useNullValue, DateTime value, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsAfter(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -110,21 +114,21 @@ namespace Valit.Tests.DateTime_
         [InlineData(false, null, false)]
         [InlineData(true, "2017-06-09", false)]
         [InlineData(true, null, false)]
-        public void DateTime_IsAfter_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue,  bool expected)
+        public void DateTime_IsAfter_Returns_Proper_Results_For_Nullable_Values(bool useNullValue, string stringValue, bool expected)
         {
             DateTime? value = stringValue.AsNullableDateTime();
 
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useNullValue? m.NullValue : m.NullableValue, _=>_
+                .Ensure(m => useNullValue ? m.NullValue : m.NullableValue, _ => _
                     .IsAfter(value))
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTime_IsAfter_Tests()
         {
             _model = new Model();
@@ -138,6 +142,6 @@ namespace Valit.Tests.DateTime_
             public DateTime? NullableValue => new DateTime(2017, 6, 10);
             public DateTime? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTime_/DateTime_IsBeforeNow_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsBeforeNow_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsBeforeNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime>)null)
                     .IsBeforeNow();
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsBeforeNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime?>)null)
                     .IsBeforeNow();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.BeforeNowValue, _=>_
+                .Ensure(m => m.BeforeNowValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.AfterNowValue, _=>_
+                .Ensure(m => m.AfterNowValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,12 +62,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                .Ensure(m => m.NullableBeforeNowValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -73,12 +75,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableAfterNowValue, _=>_
+                .Ensure(m => m.NullableAfterNowValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsBeforeNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTime_IsBeforeNow_Tests()
         {
             _model = new Model();
@@ -110,6 +112,6 @@ namespace Valit.Tests.DateTime_
             public DateTime? NullableAfterNowValue => DateTime.Now.AddDays(1);
             public DateTime? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTime_/DateTime_IsBeforeOrSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsBeforeOrSameAs_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -100,7 +100,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -121,7 +121,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/DateTime_/DateTime_IsBeforeUtcNow_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsBeforeUtcNow_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsBeforeUtcNow_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime>)null)
                     .IsBeforeUtcNow();
             });
@@ -21,7 +22,8 @@ namespace Valit.Tests.DateTime_
         [Fact]
         public void DateTime_IsBeforeUtcNow_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, DateTime?>)null)
                     .IsBeforeUtcNow();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.BeforeNowValue, _=>_
+                .Ensure(m => m.BeforeNowValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.AfterNowValue, _=>_
+                .Ensure(m => m.AfterNowValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,12 +62,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableBeforeNowValue, _=>_
+                .Ensure(m => m.NullableBeforeNowValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -73,12 +75,12 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableAfterNowValue, _=>_
+                .Ensure(m => m.NullableAfterNowValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.DateTime_
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsBeforeUtcNow())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public DateTime_IsBeforeUtcNow_Tests()
         {
             _model = new Model();
@@ -110,6 +112,6 @@ namespace Valit.Tests.DateTime_
             public DateTime? NullableAfterNowValue => DateTime.UtcNow.AddDays(1);
             public DateTime? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/DateTime_/DateTime_IsBefore_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsBefore_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -100,7 +100,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -121,7 +121,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/DateTime_/DateTime_IsSameAs_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_IsSameAs_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -100,7 +100,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -121,7 +121,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/DateTime_/DateTime_Required_Tests.cs
+++ b/tests/Valit.Tests/DateTime_/DateTime_Required_Tests.cs
@@ -31,7 +31,7 @@ namespace Valit.Tests.DateTime_
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Decimal/Decimal_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_IsEqual_To_Tests.cs
@@ -65,7 +65,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -122,7 +122,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Decimal/Decimal_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_IsGreaterThanOrEqualTo_Tests.cs
@@ -65,7 +65,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -122,7 +122,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Decimal/Decimal_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_IsGreaterThan_Tests.cs
@@ -65,7 +65,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -122,7 +122,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Decimal/Decimal_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_IsLessThanOrEqualTo_Tests.cs
@@ -65,7 +65,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -122,7 +122,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Decimal/Decimal_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_IsLessThan_Tests.cs
@@ -65,7 +65,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -122,7 +122,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Decimal/Decimal_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_IsNegative_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Decimal
         [Fact]
         public void Decimal_IsNegative_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, decimal>)null)
                     .IsNegative();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Decimal
         [Fact]
         public void Decimal_IsNegative_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, decimal?>)null)
                     .IsNegative();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Decimal_IsNegative_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.Decimal
             public decimal? NullableNegativeValue => -10;
             public decimal? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Decimal/Decimal_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Decimal
         [Fact]
         public void Decimal_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, decimal>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Decimal
         [Fact]
         public void Decimal_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, decimal?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.Decimal
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Decimal_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Decimal_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Decimal_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Decimal_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Decimal_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.Decimal
             public decimal? NullableZeroValue => 0;
             public decimal? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Decimal/Decimal_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_IsPositive_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Decimal
         [Fact]
         public void Decimal_IsPositive_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, decimal>)null)
                     .IsPositive();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Decimal
         [Fact]
         public void Decimal_IsPositive_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, decimal?>)null)
                     .IsPositive();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.Decimal
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Decimal_IsPositive_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.Decimal
             public decimal? NullableNegativeValue => -10;
             public decimal? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Decimal/Decimal_Required_Tests.cs
+++ b/tests/Valit.Tests/Decimal/Decimal_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.Decimal
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Double/Double_IsEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -93,7 +93,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -108,7 +108,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 
@@ -126,7 +126,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -144,7 +144,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -163,7 +163,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -184,7 +184,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Double/Double_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -93,7 +93,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -108,7 +108,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -125,7 +125,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -143,7 +143,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -162,7 +162,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -183,7 +183,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Double/Double_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsGreaterThan_Tests.cs
@@ -62,7 +62,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -77,7 +77,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -92,7 +92,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -107,7 +107,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -124,7 +124,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -142,7 +142,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -161,7 +161,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -182,7 +182,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Double/Double_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsLessThanOrEqualTo_Tests.cs
@@ -65,7 +65,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -95,7 +95,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -110,7 +110,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -125,7 +125,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -143,7 +143,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -162,7 +162,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -183,7 +183,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Double/Double_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsLessThan_Tests.cs
@@ -41,7 +41,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -56,7 +56,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -86,7 +86,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -144,7 +144,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -163,7 +163,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -184,7 +184,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Double/Double_IsNaN_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsNaN_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsNaN_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double>)null)
                     .IsNaN();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsNaN_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double?>)null)
                     .IsNaN();
             });
@@ -39,7 +41,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -52,7 +54,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -78,7 +80,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -91,7 +93,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         #region ARRANGE
@@ -110,6 +112,6 @@ namespace Valit.Tests.Double
             public double? NullValue => null;
             public double? NullableNaN => double.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Double/Double_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsNegative_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsNegative_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double>)null)
                     .IsNegative();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsNegative_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double?>)null)
                     .IsNegative();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -78,7 +80,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,12 +88,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -99,12 +101,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -112,12 +114,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -130,7 +132,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -143,10 +145,10 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Double_IsNegative_Tests()
         {
             _model = new Model();
@@ -166,6 +168,6 @@ namespace Valit.Tests.Double
             public double? NullValue => null;
             public double? NullableNaN => double.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Double/Double_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsNonZero_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double>)null)
                     .IsNonZero();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double?>)null)
                     .IsNonZero();
             });
@@ -37,7 +39,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -50,7 +52,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -63,22 +65,22 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Double_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Double_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Double_IsNonZero_Tests()
         {
             _model = new Model();

--- a/tests/Valit.Tests/Double/Double_IsNumber_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsNumber_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsNumber_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double>)null)
                     .IsNumber();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsNumber_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double?>)null)
                     .IsNumber();
             });
@@ -39,7 +41,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -52,7 +54,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -78,7 +80,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -91,7 +93,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         #region ARRANGE
@@ -110,6 +112,6 @@ namespace Valit.Tests.Double
             public double? NullValue => null;
             public double? NullableNaN => double.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Double/Double_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsPositive_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsPositive_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double>)null)
                     .IsPositive();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_IsPositive_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double?>)null)
                     .IsPositive();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -78,7 +80,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,12 +88,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -99,12 +101,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -112,12 +114,12 @@ namespace Valit.Tests.Double
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -130,7 +132,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -143,7 +145,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         #region ARRANGE
@@ -166,6 +168,6 @@ namespace Valit.Tests.Double
             public double? NullValue => null;
             public double? NullableNaN => double.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Double/Double_Required_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_Required_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.Double
         [Fact]
         public void Double_Required_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, double?>)null)
                     .Required();
             });
@@ -28,7 +29,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -41,7 +42,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -54,7 +55,7 @@ namespace Valit.Tests.Double
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         #region ARRANGE
@@ -71,6 +72,6 @@ namespace Valit.Tests.Double
             public double? NullValue => null;
             public double? NullableNaN => double.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Enumerable/Enumerable_MaxItems_Tests.cs
+++ b/tests/Valit.Tests/Enumerable/Enumerable_MaxItems_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.Enumerable
         [Fact]
         public void Enumerable_MaxItems_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, IEnumerable<int>>)null)
                     .MaxItems(1);
             });
@@ -23,12 +24,12 @@ namespace Valit.Tests.Enumerable
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Collection, _=>_
+                .Ensure(m => m.Collection, _ => _
                     .MaxItems(5))
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -36,12 +37,12 @@ namespace Valit.Tests.Enumerable
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Collection, _=>_
+                .Ensure(m => m.Collection, _ => _
                     .MaxItems(3))
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -49,12 +50,12 @@ namespace Valit.Tests.Enumerable
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Collection, _=>_
+                .Ensure(m => m.Collection, _ => _
                     .MaxItems(2))
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -62,15 +63,15 @@ namespace Valit.Tests.Enumerable
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullCollection, _=>_
+                .Ensure(m => m.NullCollection, _ => _
                     .MaxItems(5))
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Enumerable_MaxItems_Tests()
         {
             _model = new Model();
@@ -83,6 +84,6 @@ namespace Valit.Tests.Enumerable
             public IEnumerable<int> Collection => new List<int> { 1, 2, 3 };
             public IEnumerable<int> NullCollection => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Enumerable/Enumerable_MinItems_Tests.cs
+++ b/tests/Valit.Tests/Enumerable/Enumerable_MinItems_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Enumerable
         [Fact]
         public void Enumerable_MinItems_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, IEnumerable<int>>)null)
                     .MinItems(1);
             });
@@ -22,12 +23,12 @@ namespace Valit.Tests.Enumerable
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Collection, _=>_
+                .Ensure(m => m.Collection, _ => _
                     .MinItems(1))
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -35,12 +36,12 @@ namespace Valit.Tests.Enumerable
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Collection, _=>_
+                .Ensure(m => m.Collection, _ => _
                     .MinItems(3))
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -48,12 +49,12 @@ namespace Valit.Tests.Enumerable
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Collection, _=>_
+                .Ensure(m => m.Collection, _ => _
                     .MinItems(5))
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -61,16 +62,16 @@ namespace Valit.Tests.Enumerable
         {
             var result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullCollection, _=>_
+                .Ensure(m => m.NullCollection, _ => _
                     .MinItems(1))
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
 
-#region ARRANGE
+        #region ARRANGE
         public Enumerable_MinItems_Tests()
         {
             _model = new Model();
@@ -83,6 +84,6 @@ namespace Valit.Tests.Enumerable
             public IEnumerable<int> Collection => new List<int> { 1, 2, 3 };
             public IEnumerable<int> NullCollection => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Float/Float_IsEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -93,7 +93,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -108,7 +108,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 
@@ -126,7 +126,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -144,7 +144,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -163,7 +163,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -184,7 +184,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Float/Float_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -93,7 +93,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -108,7 +108,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -125,7 +125,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -143,7 +143,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -162,7 +162,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -183,7 +183,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Float/Float_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsGreaterThan_Tests.cs
@@ -62,7 +62,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -77,7 +77,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -92,7 +92,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -107,7 +107,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -124,7 +124,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -142,7 +142,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -161,7 +161,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -182,7 +182,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Float/Float_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsLessThanOrEqualTo_Tests.cs
@@ -65,7 +65,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -95,7 +95,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -110,7 +110,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -125,7 +125,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -143,7 +143,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -162,7 +162,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -183,7 +183,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Float/Float_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsLessThan_Tests.cs
@@ -41,7 +41,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -56,7 +56,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -86,7 +86,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -144,7 +144,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -163,7 +163,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -184,7 +184,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         #region ARRANGE

--- a/tests/Valit.Tests/Float/Float_IsNaN_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsNaN_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsNaN_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float>)null)
                     .IsNaN();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsNaN_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float?>)null)
                     .IsNaN();
             });
@@ -39,7 +41,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -52,7 +54,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -78,7 +80,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -91,7 +93,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         #region ARRANGE
@@ -110,6 +112,6 @@ namespace Valit.Tests.Float
             public float? NullValue => null;
             public float? NullableNaN => Single.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Float/Float_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsNegative_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsNegative_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float>)null)
                     .IsNegative();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsNegative_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float?>)null)
                     .IsNegative();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -78,7 +80,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,12 +88,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -99,12 +101,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -112,12 +114,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -130,7 +132,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -143,10 +145,10 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Float_IsNegative_Tests()
         {
             _model = new Model();
@@ -166,6 +168,6 @@ namespace Valit.Tests.Float
             public float? NullValue => null;
             public float? NullableNaN => Single.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Float/Float_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsNonZero_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float>)null)
                     .IsNonZero();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float?>)null)
                     .IsNonZero();
             });
@@ -37,7 +39,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -50,7 +52,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -63,22 +65,22 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Float_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Float_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -86,15 +88,15 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Float_IsNonZero_Tests()
         {
             _model = new Model();

--- a/tests/Valit.Tests/Float/Float_IsNumber_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsNumber_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsNumber_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float>)null)
                     .IsNumber();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsNumber_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float?>)null)
                     .IsNumber();
             });
@@ -39,7 +41,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -52,7 +54,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -78,7 +80,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -91,7 +93,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         #region ARRANGE
@@ -110,6 +112,6 @@ namespace Valit.Tests.Float
             public float? NullValue => null;
             public float? NullableNaN => Single.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Float/Float_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsPositive_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsPositive_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float>)null)
                     .IsPositive();
             });
@@ -20,7 +21,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_IsPositive_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float?>)null)
                     .IsPositive();
             });
@@ -34,12 +36,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -47,12 +49,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -78,7 +80,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -86,12 +88,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -99,12 +101,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -112,12 +114,12 @@ namespace Valit.Tests.Float
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -130,7 +132,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -143,7 +145,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         #region ARRANGE
@@ -166,6 +168,6 @@ namespace Valit.Tests.Float
             public float? NullValue => null;
             public float? NullableNaN => Single.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Float/Float_Required_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_Required_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.Float
         [Fact]
         public void Float_Required_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, float?>)null)
                     .Required();
             });
@@ -28,7 +29,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -41,7 +42,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -54,7 +55,7 @@ namespace Valit.Tests.Float
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         #region ARRANGE
@@ -71,6 +72,6 @@ namespace Valit.Tests.Float
             public float? NullValue => null;
             public float? NullableNaN => Single.NaN;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int16/Int16_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_IsEqual_To_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int16/Int16_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int16/Int16_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_IsGreaterThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int16/Int16_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_IsLessThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int16/Int16_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_IsLessThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int16/Int16_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_IsNegative_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int16
         [Fact]
         public void Int16_IsNegative_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, short>)null)
                     .IsNegative();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int16
         [Fact]
         public void Int16_IsNegative_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, short?>)null)
                     .IsNegative();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int16_IsNegative_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.Int16
             public short? NullableNegativeValue => -10;
             public short? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int16/Int16_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int16
         [Fact]
         public void Int16_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, short>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int16
         [Fact]
         public void Int16_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, short?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.Int16
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Int16_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Int16_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Int16_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Int16_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int16_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.Int16
             public short? NullableZeroValue => 0;
             public short? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int16/Int16_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_IsPositive_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int16
         [Fact]
         public void Int16_IsPositive_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, short>)null)
                     .IsPositive();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int16
         [Fact]
         public void Int16_IsPositive_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, short?>)null)
                     .IsPositive();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.Int16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int16_IsPositive_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.Int16
             public short? NullableNegativeValue => -10;
             public short? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int16/Int16_Required_Tests.cs
+++ b/tests/Valit.Tests/Int16/Int16_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.Int16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int32/Int32_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_IsEqual_To_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int32/Int32_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int32/Int32_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_IsGreaterThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int32/Int32_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_IsLessThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int32/Int32_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_IsLessThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int32/Int32_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_IsNegative_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int32
         [Fact]
         public void Int32_IsNegative_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, int>)null)
                     .IsNegative();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int32
         [Fact]
         public void Int32_IsNegative_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, int?>)null)
                     .IsNegative();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int32_IsNegative_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.Int32
             public int? NullableNegativeValue => -10;
             public int? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int32/Int32_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int32
         [Fact]
         public void Int32_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, int>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int32
         [Fact]
         public void Int32_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, int?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.Int32
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Int32_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Int32_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Int32_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Int32_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int32_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.Int32
             public int? NullableZeroValue => 0;
             public int? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int32/Int32_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_IsPositive_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int32
         [Fact]
         public void Int32_IsPositive_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, int>)null)
                     .IsPositive();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int32
         [Fact]
         public void Int32_IsPositive_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, int?>)null)
                     .IsPositive();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.Int32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int32_IsPositive_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.Int32
             public int? NullableNegativeValue => -10;
             public int? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int32/Int32_Required_Tests.cs
+++ b/tests/Valit.Tests/Int32/Int32_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.Int32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int64/Int64_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_IsEqual_To_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int64/Int64_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int64/Int64_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_IsGreaterThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int64/Int64_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_IsLessThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int64/Int64_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_IsLessThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Int64/Int64_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_IsNegative_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int64
         [Fact]
         public void Int64_IsNegative_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, long>)null)
                     .IsNegative();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int64
         [Fact]
         public void Int64_IsNegative_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, long?>)null)
                     .IsNegative();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int64_IsNegative_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.Int64
             public long? NullableNegativeValue => -10;
             public long? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int64/Int64_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int64
         [Fact]
         public void Int64_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, long>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int64
         [Fact]
         public void Int64_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, long?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.Int64
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Int64_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Int64_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void Int64_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void Int64_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int64_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.Int64
             public long? NullableZeroValue => 0;
             public long? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int64/Int64_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_IsPositive_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.Int64
         [Fact]
         public void Int64_IsPositive_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, long>)null)
                     .IsPositive();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.Int64
         [Fact]
         public void Int64_IsPositive_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, long?>)null)
                     .IsPositive();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.Int64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public Int64_IsPositive_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.Int64
             public long? NullableNegativeValue => -10;
             public long? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/Int64/Int64_Required_Tests.cs
+++ b/tests/Valit.Tests/Int64/Int64_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.Int64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/NestedObject/Nested_Object_Collection_Validation_Tests.cs
+++ b/tests/Valit.Tests/NestedObject/Nested_Object_Collection_Validation_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.NestedObject
         [Fact]
         public void EnsureFor_Throws_When_Null_ValitRulesProvider_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ValitRules<Model>
                     .Create()
                     .EnsureFor(m => m.NestedObjectCollection, ((IValitRulesProvider<NestedModel>)null));
@@ -30,7 +31,7 @@ namespace Valit.Tests.NestedObject
                 .For(rootObject)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
             result.ErrorMessages.Count(m => m == "One").ShouldBe(1);
             result.ErrorMessages.Count(m => m == "Two").ShouldBe(1);
             result.ErrorMessages.Count(m => m == "Three").ShouldBe(2);
@@ -48,7 +49,7 @@ namespace Valit.Tests.NestedObject
                 .For(rootObject)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
             result.ErrorMessages.Count().ShouldBe(1);
             result.ErrorMessages.First().ShouldBe("Two");
         }
@@ -64,7 +65,7 @@ namespace Valit.Tests.NestedObject
                 .For(rootObject)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -79,10 +80,10 @@ namespace Valit.Tests.NestedObject
                 .For(rootObject)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
-#region  ARRANGE
+        #region  ARRANGE
         class Model
         {
             public IEnumerable<NestedModel> NestedObjectCollection { get; set; }
@@ -110,8 +111,8 @@ namespace Valit.Tests.NestedObject
 
         class NestedModel
         {
-            public ushort NumericValue { get; set;}
-            public string StringValue { get; set;}
+            public ushort NumericValue { get; set; }
+            public string StringValue { get; set; }
         }
 
         class NestedModelRulesProvider : IValitRulesProvider<NestedModel>
@@ -119,10 +120,10 @@ namespace Valit.Tests.NestedObject
             public IEnumerable<IValitRule<NestedModel>> GetRules()
                 => ValitRules<NestedModel>
                         .Create()
-                        .Ensure(m => m.NumericValue, _=>_
+                        .Ensure(m => m.NumericValue, _ => _
                             .IsGreaterThan(10)
                                 .WithMessage("One"))
-                        .Ensure(m => m.StringValue, _=>_
+                        .Ensure(m => m.StringValue, _ => _
                             .Required()
                                 .WithMessage("Two")
                             .Email()
@@ -130,5 +131,5 @@ namespace Valit.Tests.NestedObject
                         .GetAllRules();
         }
     }
-#endregion
+    #endregion
 }

--- a/tests/Valit.Tests/NestedObject/Nested_Object_Validation_Tests.cs
+++ b/tests/Valit.Tests/NestedObject/Nested_Object_Validation_Tests.cs
@@ -10,7 +10,8 @@ namespace Valit.Tests.NestedObject
         [Fact]
         public void Ensure_Throws_When_Null_ValitRulesProvider_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ValitRules<Model>
                     .Create()
                     .Ensure(m => m.NestedObject, ((IValitRulesProvider<NestedModel>)null));
@@ -30,7 +31,7 @@ namespace Valit.Tests.NestedObject
                 .For(rootObject)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -60,10 +61,10 @@ namespace Valit.Tests.NestedObject
                 .For(rootObject)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
-#region  ARRANGE
+        #region  ARRANGE
         class Model
         {
             public NestedModel NestedObject { get; set; }
@@ -91,8 +92,8 @@ namespace Valit.Tests.NestedObject
 
         class NestedModel
         {
-            public ushort NumericValue { get; set;}
-            public string StringValue { get; set;}
+            public ushort NumericValue { get; set; }
+            public string StringValue { get; set; }
         }
 
         class NestedModelRulesProvider : IValitRulesProvider<NestedModel>
@@ -100,10 +101,10 @@ namespace Valit.Tests.NestedObject
             public IEnumerable<IValitRule<NestedModel>> GetRules()
                 => ValitRules<NestedModel>
                         .Create()
-                        .Ensure(m => m.NumericValue, _=>_
+                        .Ensure(m => m.NumericValue, _ => _
                             .IsGreaterThan(10)
                                 .WithMessage("One"))
-                        .Ensure(m => m.StringValue, _=>_
+                        .Ensure(m => m.StringValue, _ => _
                             .Required()
                                 .WithMessage("Two")
                             .Email()
@@ -111,5 +112,5 @@ namespace Valit.Tests.NestedObject
                         .GetAllRules();
         }
     }
-#endregion
+    #endregion
 }

--- a/tests/Valit.Tests/Property/Property_Tag_Tests.cs
+++ b/tests/Valit.Tests/Property/Property_Tag_Tests.cs
@@ -111,7 +111,7 @@ namespace Valit.Tests.Property
                 .For(_model)
                 .Validate(tags);
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -137,7 +137,7 @@ namespace Valit.Tests.Property
                 .For(_model)
                 .Validate(r => r.Tags.Intersect(tags).Any());
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]

--- a/tests/Valit.Tests/SByte/SByte_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_IsEqual_To_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/SByte/SByte_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/SByte/SByte_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_IsGreaterThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/SByte/SByte_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_IsLessThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/SByte/SByte_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_IsLessThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/SByte/SByte_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_IsNegative_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.SByte
         [Fact]
         public void SByte_IsNegative_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, sbyte>)null)
                     .IsNegative();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.SByte
         [Fact]
         public void SByte_IsNegative_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, sbyte?>)null)
                     .IsNegative();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNegative())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public SByte_IsNegative_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.SByte
             public sbyte? NullableNegativeValue => -10;
             public sbyte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/SByte/SByte_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.SByte
         [Fact]
         public void SByte_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, sbyte>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.SByte
         [Fact]
         public void SByte_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, sbyte?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.SByte
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void SByte_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void SByte_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void SByte_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void SByte_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public SByte_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.SByte
             public sbyte? NullableZeroValue => 0;
             public sbyte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/SByte/SByte_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_IsPositive_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.SByte
         [Fact]
         public void SByte_IsPositive_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, sbyte>)null)
                     .IsPositive();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.SByte
         [Fact]
         public void SByte_IsPositive_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, sbyte?>)null)
                     .IsPositive();
             });
@@ -33,12 +35,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.PositiveValue, _=>_
+                .Ensure(m => m.PositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -46,12 +48,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.ZeroValue, _=>_
+                .Ensure(m => m.ZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -59,12 +61,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NegativeValue, _=>_
+                .Ensure(m => m.NegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,12 +74,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullablePositiveValue, _=>_
+                .Ensure(m => m.NullablePositiveValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, true);
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableZeroValue, _=>_
+                .Ensure(m => m.NullableZeroValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -98,12 +100,12 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullableNegativeValue, _=>_
+                .Ensure(m => m.NullableNegativeValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -111,15 +113,15 @@ namespace Valit.Tests.SByte
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsPositive())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public SByte_IsPositive_Tests()
         {
             _model = new Model();
@@ -137,6 +139,6 @@ namespace Valit.Tests.SByte
             public sbyte? NullableNegativeValue => -10;
             public sbyte? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/SByte/SByte_Required_Tests.cs
+++ b/tests/Valit.Tests/SByte/SByte_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.SByte
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/String/String_Required_Tests.cs
+++ b/tests/Valit.Tests/String/String_Required_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.String
         [Fact]
         public void String_Required_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, string>)null)
                     .Required();
             });
@@ -23,12 +24,12 @@ namespace Valit.Tests.String
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .Required())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -36,12 +37,12 @@ namespace Valit.Tests.String
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.EmptyValue, _=>_
+                .Ensure(m => m.EmptyValue, _ => _
                     .Required())
                 .For(_model)
                 .Validate();
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
         }
 
         [Fact]
@@ -49,15 +50,15 @@ namespace Valit.Tests.String
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.Value, _=>_
+                .Ensure(m => m.Value, _ => _
                     .Required())
                 .For(_model)
                 .Validate();
 
-            Assert.True(result.Succeeded);
+            result.Succeeded.ShouldBeTrue();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public String_Required_Tests()
         {
             _model = new Model();
@@ -71,6 +72,6 @@ namespace Valit.Tests.String
             public string Value => "text";
             public string NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/UInt16/UInt16_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/UInt16/UInt16_IsEqual_To_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt16/UInt16_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/UInt16/UInt16_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt16/UInt16_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/UInt16/UInt16_IsGreaterThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt16/UInt16_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/UInt16/UInt16_IsLessThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt16/UInt16_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/UInt16/UInt16_IsLessThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt16/UInt16_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/UInt16/UInt16_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.UInt16
         [Fact]
         public void UInt16_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, ushort>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.UInt16
         [Fact]
         public void UInt16_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, ushort?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.UInt16
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void UInt16_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void UInt16_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void UInt16_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void UInt16_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.UInt16
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public UInt16_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.UInt16
             public ushort? NullableZeroValue => 0;
             public ushort? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/UInt16/UInt16_Required_Tests.cs
+++ b/tests/Valit.Tests/UInt16/UInt16_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.UInt16
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt32/UInt32_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/UInt32/UInt32_IsEqual_To_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt32/UInt32_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/UInt32/UInt32_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt32/UInt32_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/UInt32/UInt32_IsGreaterThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt32/UInt32_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/UInt32/UInt32_IsLessThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt32/UInt32_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/UInt32/UInt32_IsLessThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt32/UInt32_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/UInt32/UInt32_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.UInt32
         [Fact]
         public void UInt32_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, uint>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.UInt32
         [Fact]
         public void UInt32_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, uint?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.UInt32
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void UInt32_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void UInt32_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void UInt32_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void UInt32_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.UInt32
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public UInt32_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.UInt32
             public uint? NullableZeroValue => 0;
             public uint? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/UInt32/UInt32_Required_Tests.cs
+++ b/tests/Valit.Tests/UInt32/UInt32_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.UInt32
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt64/UInt64_IsEqual_To_Tests.cs
+++ b/tests/Valit.Tests/UInt64/UInt64_IsEqual_To_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt64/UInt64_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/UInt64/UInt64_IsGreaterThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt64/UInt64_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/UInt64/UInt64_IsGreaterThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt64/UInt64_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/UInt64/UInt64_IsLessThanOrEqualTo_Tests.cs
@@ -63,7 +63,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt64/UInt64_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/UInt64/UInt64_IsLessThan_Tests.cs
@@ -64,7 +64,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/UInt64/UInt64_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/UInt64/UInt64_IsNonZero_Tests.cs
@@ -8,7 +8,8 @@ namespace Valit.Tests.UInt64
         [Fact]
         public void UInt64_IsNonZero_For_Not_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, ulong>)null)
                     .IsNonZero();
             });
@@ -19,7 +20,8 @@ namespace Valit.Tests.UInt64
         [Fact]
         public void UInt64_IsNonZero_For_Nullable_Value_Throws_When_Null_Rule_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 ((IValitRule<Model, ulong?>)null)
                     .IsNonZero();
             });
@@ -31,31 +33,31 @@ namespace Valit.Tests.UInt64
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void UInt64_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue,  bool expected)
+        public void UInt64_IsNonZero_Returns_Proper_Results_For_Not_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.ZeroValue : m.Value, _=>_
+                .Ensure(m => useZeroValue ? m.ZeroValue : m.Value, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
-        public void UInt64_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue,  bool expected)
+        public void UInt64_IsNonZero_Returns_Proper_Results_For_Nullable_Value(bool useZeroValue, bool expected)
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => useZeroValue? m.NullableZeroValue : m.NullableValue, _=>_
+                .Ensure(m => useZeroValue ? m.NullableZeroValue : m.NullableValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
         [Fact]
@@ -63,15 +65,15 @@ namespace Valit.Tests.UInt64
         {
             IValitResult result = ValitRules<Model>
                 .Create()
-                .Ensure(m => m.NullValue, _=>_
+                .Ensure(m => m.NullValue, _ => _
                     .IsNonZero())
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, false);
+            result.Succeeded.ShouldBeFalse();
         }
 
-#region ARRANGE
+        #region ARRANGE
         public UInt64_IsNonZero_Tests()
         {
             _model = new Model();
@@ -87,6 +89,6 @@ namespace Valit.Tests.UInt64
             public ulong? NullableZeroValue => 0;
             public ulong? NullValue => null;
         }
-#endregion
+        #endregion
     }
 }

--- a/tests/Valit.Tests/UInt64/UInt64_Required_Tests.cs
+++ b/tests/Valit.Tests/UInt64/UInt64_Required_Tests.cs
@@ -30,7 +30,7 @@ namespace Valit.Tests.UInt64
                 .For(_model)
                 .Validate();
 
-            Assert.Equal(result.Succeeded, expected);
+            result.Succeeded.ShouldBe(expected);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/Valitator/Valitator_MessageProvider_Tests.cs
+++ b/tests/Valit.Tests/Valitator/Valitator_MessageProvider_Tests.cs
@@ -9,7 +9,8 @@ namespace Valit.Tests.Valitator
         [Fact]
         public void CreateValitator_Throws_When_Null_ValitRulesProvider_Is_Given()
         {
-            var exception = Record.Exception(() => {
+            var exception = Record.Exception(() =>
+            {
                 var valitator = ((IValitRulesProvider<Model>)null).CreateValitator();
             });
 
@@ -22,7 +23,7 @@ namespace Valit.Tests.Valitator
             var valitator = new ModelRulesProvider().CreateValitator();
             var result = valitator.Validate(_model);
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
             result.ErrorMessages.ShouldContain("One");
             result.ErrorMessages.ShouldNotContain("Two");
             result.ErrorMessages.ShouldContain("Three");
@@ -34,14 +35,14 @@ namespace Valit.Tests.Valitator
             var valitator = new ModelRulesProvider().CreateValitator();
             var result = valitator.Validate(_model, new FailFastValitStrategy());
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
             result.ErrorMessages.ShouldContain("One");
             result.ErrorMessages.ShouldNotContain("Two");
             result.ErrorMessages.ShouldNotContain("Three");
         }
 
 
-#region  ARRANGE
+        #region  ARRANGE
 
         class Model
         {
@@ -54,10 +55,10 @@ namespace Valit.Tests.Valitator
             public IEnumerable<IValitRule<Model>> GetRules()
                 => ValitRules<Model>
                         .Create()
-                        .Ensure(m => m.NumericValue, _=>_
+                        .Ensure(m => m.NumericValue, _ => _
                             .IsGreaterThan(10)
                                 .WithMessage("One"))
-                        .Ensure(m => m.StringValue, _=>_
+                        .Ensure(m => m.StringValue, _ => _
                             .Required()
                                 .WithMessage("Two")
                             .Email()
@@ -76,6 +77,6 @@ namespace Valit.Tests.Valitator
             };
         }
     }
-#endregion
+    #endregion
 
 }

--- a/tests/Valit.Tests/Valitator/Valitator_ValitRules_Tests.cs
+++ b/tests/Valit.Tests/Valitator/Valitator_ValitRules_Tests.cs
@@ -22,7 +22,7 @@ namespace Valit.Tests.Valitator
             var valitator = _valitRules.CreateValitator();
             var result = valitator.Validate(_model);
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
             result.ErrorMessages.ShouldContain("One");
             result.ErrorMessages.ShouldNotContain("Two");
             result.ErrorMessages.ShouldContain("Three");
@@ -34,7 +34,7 @@ namespace Valit.Tests.Valitator
             var valitator = _valitRules.CreateValitator();
             var result = valitator.Validate(_model, new FailFastValitStrategy());
 
-            Assert.False(result.Succeeded);
+            result.Succeeded.ShouldBeFalse();
             result.ErrorMessages.ShouldContain("One");
             result.ErrorMessages.ShouldNotContain("Two");
             result.ErrorMessages.ShouldNotContain("Three");


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. #135 

# Changes
-  `Assert.Equal(result.Succeeded, expected);` -> `result.Succeeded.ShouldBe(expected);`
-  `Assert.False(result.Succeeded);` -> `result.Succeeded.ShouldBeFalse();`
-  `Assert.True(result.Succeeded);` -> `result.Succeeded.ShouldBeTrue();`