### PR TITLE
Added support for default messages

### DIFF
--- a/src/Valit/Errors/ErrorMessages.cs
+++ b/src/Valit/Errors/ErrorMessages.cs
@@ -1,0 +1,31 @@
+namespace Valit.Errors
+{
+    internal static class ErrorMessages
+    {
+        internal static string Required => "The {0} field is required.";
+        internal static string Satisifes => "The {0} field does not satisfy the rule.";
+        internal static string IsTrue => "The {0} field is not true.";
+        internal static string IsFalse => "The {0} field is not false.";
+        internal static string IsEqualTo => "The {0} field is not equal to {1}.";
+        internal static string IsGreaterThan => "The {0} field is not greater than {1}.";
+        internal static string IsGreaterThanOrEqualTo => "The {0} field is not greater than or equal to {1}.";
+        internal static string IsLessThan => "The {0} field is not less than {1}.";
+        internal static string IsLessThanOrEqualTo => "The {0} field is not less than or equal to {1}.";
+        internal static string IsNonZero => "The {0} field is a zero.";
+        internal static string IsAfter => "The {0} field is not after {1}.";
+        internal static string IsAfterOrSameAs => "The {0} field is not after or same as {1}.";
+        internal static string IsBefore => "The {0} field is not before {1}.";
+        internal static string IsBeforeOrSameAs => "The {0} field is not before or same as {1}.";
+        internal static string IsSameAs => "The {0} field is not same as {1}.";
+        internal static string IsNegative => "The {0} field is not a negative number.";
+        internal static string IsPositive => "The {0} field is not a positive number.";
+        internal static string IsNaN => "The {0} field is not NaN.";
+        internal static string IsNumber => "The {0} field is not a number.";
+        internal static string MinItems => "The {0} field has less than {1} elements.";
+        internal static string MaxItems => "The {0} field has more than {1} elements.";
+        internal static string Email => "The {0} field is not valid email.";
+        internal static string Matches => "The {0} field does not match the patter.";
+        internal static string MinLength => "The {0} field's length is less than {1}.";
+        internal static string MaxLength => "The {0} field's length is greater than {1}.";
+    }
+}

--- a/src/Valit/Errors/ErrorMessages.cs
+++ b/src/Valit/Errors/ErrorMessages.cs
@@ -27,5 +27,6 @@ namespace Valit.Errors
         internal static string Matches => "The {0} field does not match the patter.";
         internal static string MinLength => "The {0} field's length is less than {1}.";
         internal static string MaxLength => "The {0} field's length is greater than {1}.";
+        internal static string IsNotEmpty => "The {0} field is empty.";
     }
 }

--- a/src/Valit/Errors/ErrorMessages.cs
+++ b/src/Valit/Errors/ErrorMessages.cs
@@ -3,6 +3,7 @@ namespace Valit.Errors
     internal static class ErrorMessages
     {
         internal static string Required => "The {0} field is required.";
+        internal static string Satisifes => "The {0} field does not satisfy the rule.";
         internal static string IsTrue => "The {0} field is not true.";
         internal static string IsFalse => "The {0} field is not false.";
         internal static string IsEqualTo => "The {0} field is not equal to {1}.";

--- a/src/Valit/Errors/ErrorMessages.cs
+++ b/src/Valit/Errors/ErrorMessages.cs
@@ -23,7 +23,7 @@ namespace Valit.Errors
         internal static string MinItems => "The {0} field has less than {1} elements.";
         internal static string MaxItems => "The {0} field has more than {1} elements.";
         internal static string Email => "The {0} field is not valid email.";
-        internal static string Matches => "The {0} field does not match the patter.";
+        internal static string Matches => "The {0} field does not match the pattern.";
         internal static string MinLength => "The {0} field's length is less than {1}.";
         internal static string MaxLength => "The {0} field's length is greater than {1}.";
         internal static string IsNotEmpty => "The {0} field is empty.";

--- a/src/Valit/Errors/ErrorMessages.cs
+++ b/src/Valit/Errors/ErrorMessages.cs
@@ -3,7 +3,6 @@ namespace Valit.Errors
     internal static class ErrorMessages
     {
         internal static string Required => "The {0} field is required.";
-        internal static string Satisifes => "The {0} field does not satisfy the rule.";
         internal static string IsTrue => "The {0} field is not true.";
         internal static string IsFalse => "The {0} field is not false.";
         internal static string IsEqualTo => "The {0} field is not equal to {1}.";

--- a/src/Valit/Errors/ValitRuleError.cs
+++ b/src/Valit/Errors/ValitRuleError.cs
@@ -7,20 +7,23 @@ namespace Valit.Errors
         private readonly Func<string> _messageFunc;
         public string Message => _messageFunc();
         public int? ErrorCode { get; }
+        public bool IsDefault { get; }
 
-        private ValitRuleError(Func<string> messageFunc)
+        private ValitRuleError(Func<string> messageFunc, bool isDefault)
         {
+            IsDefault = isDefault;            
             _messageFunc = messageFunc;
         }
 
         private ValitRuleError(int errorCode)
         {
-            ErrorCode = errorCode;
+            ErrorCode = errorCode;            
+            IsDefault = false;
             _messageFunc = () => string.Empty;
         }
 
-        public static ValitRuleError CreateForMessage(Func<string> messageFunc)
-            => new ValitRuleError(messageFunc);
+        public static ValitRuleError CreateForMessage(Func<string> messageFunc, bool isDefault = false)
+            => new ValitRuleError(messageFunc, isDefault);
 
         public static ValitRuleError CreateForErrorCode(int errorCode)
             => new ValitRuleError(errorCode);

--- a/src/Valit/IValitRules.cs
+++ b/src/Valit/IValitRules.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace Valit
 {
     public interface IValitRules<TObject> where TObject : class
     {
-        IValitRules<TObject> Ensure<TProperty>(Func<TObject, TProperty> selector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc);
-        IValitRules<TObject> Ensure<TProperty>(Func<TObject, TProperty> selector, IValitator<TProperty> valitator) where TProperty : class;
-        IValitRules<TObject> EnsureFor<TProperty>(Func<TObject, IEnumerable<TProperty>> selector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc);
-        IValitRules<TObject> EnsureFor<TProperty>(Func<TObject, IEnumerable<TProperty>> selector, IValitator<TProperty> valitator) where TProperty : class;
+        IValitRules<TObject> Ensure<TProperty>(Expression<Func<TObject, TProperty>> selector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc);
+        IValitRules<TObject> Ensure<TProperty>(Expression<Func<TObject, TProperty>> selector, IValitator<TProperty> valitator) where TProperty : class;
+        IValitRules<TObject> EnsureFor<TProperty>(Expression<Func<TObject, IEnumerable<TProperty>>> selector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc);
+        IValitRules<TObject> EnsureFor<TProperty>(Expression<Func<TObject, IEnumerable<TProperty>>> selector, IValitator<TProperty> valitator) where TProperty : class;
         IValitRules<TObject> For(TObject @object);
         IEnumerable<IValitRule<TObject>> GetAllRules();
         IEnumerable<IValitRule<TObject>> GetTaggedRules();

--- a/src/Valit/Rules/CollectionValitRule.cs
+++ b/src/Valit/Rules/CollectionValitRule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Valit.Exceptions;
 using Valit.Result;
 
@@ -10,13 +11,13 @@ namespace Valit.Rules
     {
         public IEnumerable<string> Tags { get; private set; }
 
-        private readonly Func<TObject, IEnumerable<TProperty>> _collectionSelector;
+        private readonly Expression<Func<TObject, IEnumerable<TProperty>>> _collectionSelector;
         private readonly Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> _ruleFunc;
         private readonly IValitStrategy _strategy;
         private readonly IValitMessageProvider _messageProvider;
 
         public CollectionValitRule(
-            Func<TObject, IEnumerable<TProperty>> collectionSelector,
+            Expression<Func<TObject, IEnumerable<TProperty>>> collectionSelector,
             Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> ruleFunc,
             IValitStrategy strategy,
             IValitMessageProvider messageProvider)
@@ -32,11 +33,11 @@ namespace Valit.Rules
         {
             @object.ThrowIfNull();
 
-            var collection = _collectionSelector(@object);
+            var collection = _collectionSelector.Compile().Invoke(@object);
 
             var rules = collection.SelectMany(p => 
             {
-                Func<TObject, TProperty> selector = _ => p;
+                Expression<Func<TObject, TProperty>> selector = _ => p;
                 var lastEnsureRule = _ruleFunc(new ValitRule<TObject, TProperty>(selector, _messageProvider));
                 return lastEnsureRule.GetAllEnsureRules();
             });

--- a/src/Valit/Rules/IValitRuleAccessor.cs
+++ b/src/Valit/Rules/IValitRuleAccessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq.Expressions;
 using Valit.Errors;
 
 namespace Valit.Rules
@@ -14,7 +15,7 @@ namespace Valit.Rules
 
     internal interface IValitRuleAccessor<TObject, TProperty> : IValitRuleAccessor where TObject : class
     {
-        Func<TObject, TProperty> PropertySelector { get; }
+        Expression<Func<TObject, TProperty>> PropertySelector { get; }
         IValitRule<TObject, TProperty> PreviousRule { get; }
         void SetPredicate(Predicate<TProperty> predicate);
         void AddCondition(Predicate<TObject> condition);

--- a/src/Valit/Rules/NestedObjectCollectionValitRule.cs
+++ b/src/Valit/Rules/NestedObjectCollectionValitRule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Valit.Exceptions;
 using Valit.Result;
 
@@ -9,12 +10,12 @@ namespace Valit.Rules
     internal class NestedObjectCollectionValitRule<TObject, TProperty> : IValitRule<TObject> where TObject : class where TProperty : class
     {
         public IEnumerable<string> Tags { get; private set; }
-        private readonly Func<TObject, IEnumerable<TProperty>> _collectionSelector;
+        private readonly Expression<Func<TObject, IEnumerable<TProperty>>> _collectionSelector;
         private readonly IValitator<TProperty> _valitator;
         private readonly IValitStrategy _strategy;
 
         public NestedObjectCollectionValitRule(
-            Func<TObject, IEnumerable<TProperty>> collectionSelector,
+            Expression<Func<TObject, IEnumerable<TProperty>>> collectionSelector,
             IValitator<TProperty> valitator,
             IValitStrategy strategy)
         {
@@ -28,11 +29,11 @@ namespace Valit.Rules
         {
             @object.ThrowIfNull();
 
-            var collection = _collectionSelector(@object);
+            var collection = _collectionSelector.Compile().Invoke(@object);
 
             var rules = collection.Select(p => 
             {
-                Func<TObject, TProperty> selector = _ => p;
+                Expression<Func<TObject, TProperty>> selector = _ => p;
                 return new NestedObjectValitRule<TObject, TProperty>(selector, _valitator, _strategy);
             });
 

--- a/src/Valit/Rules/NestedObjectValitRule.cs
+++ b/src/Valit/Rules/NestedObjectValitRule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Valit.Exceptions;
 
 namespace Valit.Rules
@@ -8,17 +9,17 @@ namespace Valit.Rules
     internal class NestedObjectValitRule<TObject, TProperty> : IValitRule<TObject> where TObject : class where TProperty : class
     {
         public IEnumerable<string> Tags { get; set; }
-        private readonly Func<TObject, TProperty> _propertySelector;
+        private readonly Expression<Func<TObject, TProperty>> _propertySelector;
         private readonly IValitator<TProperty> _valitator;
         private readonly IValitStrategy _strategy;
 
         public NestedObjectValitRule(
-            Func<TObject, TProperty> selector,
+            Expression<Func<TObject, TProperty>> propertySelector,
             IValitator<TProperty> valitator,
             IValitStrategy strategy)
         {
             Tags = Enumerable.Empty<string>();
-            _propertySelector = selector;
+            _propertySelector = propertySelector;
             _valitator = valitator;
             _strategy = strategy;
         }
@@ -27,7 +28,7 @@ namespace Valit.Rules
         {
             @object.ThrowIfNull();
 
-            var property = _propertySelector(@object);
+            var property = _propertySelector.Compile().Invoke(@object);
             return _valitator.Validate(property, _strategy);
         }
     }

--- a/src/Valit/Rules/ValitRule.cs
+++ b/src/Valit/Rules/ValitRule.cs
@@ -76,7 +76,7 @@ namespace Valit.Rules
                 hasAllConditionsFulfilled &= condition(@object);
 
             var isSatisfied = _predicate?.Invoke(property) != false;
-            var errors = _errors.Where(e => e.Message != null).Count() > 1? _errors.Skip(1) : _errors;
+            var errors = _errors.Where(e => !e.IsDefault).Any() ? _errors.Where(e => !e.IsDefault) : _errors;
 
             return !hasAllConditionsFulfilled || isSatisfied ? ValitResult.Success : ValitResult.Fail(errors.ToArray());
         }

--- a/src/Valit/Rules/ValitRule.cs
+++ b/src/Valit/Rules/ValitRule.cs
@@ -51,7 +51,16 @@ namespace Valit.Rules
             => _predicate != null;
 
         void IValitRuleAccessor.AddError(ValitRuleError error)
-            => _errors.Add(error);
+        {
+            var areAnyDefaultMessages = _errors.Any(e => e.IsDefault);
+
+            if(error.IsDefault && areAnyDefaultMessages)
+            {
+                _errors.Clear();
+            }
+            
+            _errors.Add(error);
+        }
 
         void IValitRuleAccessor<TObject, TProperty>.AddCondition(Predicate<TObject> condition)
             => _conditions.Add(condition);

--- a/src/Valit/Rules/ValitRule.cs
+++ b/src/Valit/Rules/ValitRule.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Valit.Errors;
 using Valit.Exceptions;
 using Valit.Result;
@@ -74,8 +75,9 @@ namespace Valit.Rules
                 hasAllConditionsFulfilled &= condition(@object);
 
             var isSatisfied = _predicate?.Invoke(property) != false;
+            var errors = _errors.Where(e => e.Message != null).Count() > 1? _errors.Skip(1) : _errors;
 
-            return !hasAllConditionsFulfilled || isSatisfied ? ValitResult.Success : ValitResult.Fail(_errors.ToArray());
+            return !hasAllConditionsFulfilled || isSatisfied ? ValitResult.Success : ValitResult.Fail(errors.ToArray());
         }
     }
 }

--- a/src/Valit/Rules/ValitRule.cs
+++ b/src/Valit/Rules/ValitRule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Valit.Errors;
 using Valit.Exceptions;
 using Valit.Result;
@@ -11,10 +12,10 @@ namespace Valit.Rules
     {
         public IEnumerable<string> Tags => _tags;
 
-        Func<TObject, TProperty> IValitRuleAccessor<TObject, TProperty>.PropertySelector => _propertySelector;
+        Expression<Func<TObject, TProperty>> IValitRuleAccessor<TObject, TProperty>.PropertySelector => _propertySelector;
         IValitRule<TObject, TProperty> IValitRuleAccessor<TObject, TProperty>.PreviousRule => _previousRule;
 
-        private readonly Func<TObject, TProperty> _propertySelector;
+        private readonly Expression<Func<TObject, TProperty>> _propertySelector;
         private Predicate<TProperty> _predicate;
         private readonly List<Predicate<TObject>> _conditions;
         private readonly IValitRule<TObject, TProperty> _previousRule;
@@ -30,7 +31,7 @@ namespace Valit.Rules
             _messageProvider = previousRuleAccessor.GetMessageProvider();
         }
 
-        internal ValitRule(Func<TObject, TProperty> propertySelector, IValitMessageProvider messageProvider) : this()
+        internal ValitRule(Expression<Func<TObject, TProperty>> propertySelector, IValitMessageProvider messageProvider) : this()
         {
             _propertySelector = propertySelector;
             _messageProvider = messageProvider;
@@ -68,7 +69,7 @@ namespace Valit.Rules
         {
             @object.ThrowIfNull();
 
-            var property = _propertySelector(@object);
+            var property = _propertySelector.Compile().Invoke(@object);
             var hasAllConditionsFulfilled = true;
 
             foreach(var condition in _conditions)

--- a/src/Valit/ValitRuleBooleanExtensions.cs
+++ b/src/Valit/ValitRuleBooleanExtensions.cs
@@ -5,30 +5,30 @@ namespace Valit
     public static class ValitRuleBooleanExtensions
     {
         public static IValitRule<TObject, bool> IsTrue<TObject>(this IValitRule<TObject, bool> rule) where TObject : class
-            => rule.Satisfies(p => p);
+            => rule.Satisfies(p => p).WithDefaultMessage(ErrorMessages.IsTrue);
 
         public static IValitRule<TObject, bool?> IsTrue<TObject>(this IValitRule<TObject, bool?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p == true);
+            => rule.Satisfies(p => p.HasValue && p == true).WithDefaultMessage(ErrorMessages.IsTrue);
 
         public static IValitRule<TObject, bool> IsFalse<TObject>(this IValitRule<TObject, bool> rule) where TObject : class
-            => rule.Satisfies(p => !p);
+            => rule.Satisfies(p => !p).WithDefaultMessage(ErrorMessages.IsFalse);
 
         public static IValitRule<TObject, bool?> IsFalse<TObject>(this IValitRule<TObject, bool?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p == false);
+            => rule.Satisfies(p => p.HasValue && p == false).WithDefaultMessage(ErrorMessages.IsFalse);
 
         public static IValitRule<TObject, bool> IsEqualTo<TObject>(this IValitRule<TObject, bool> rule, bool value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, bool> IsEqualTo<TObject>(this IValitRule<TObject, bool> rule, bool? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, bool?> IsEqualTo<TObject>(this IValitRule<TObject, bool?> rule, bool value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, bool?> IsEqualTo<TObject>(this IValitRule<TObject, bool?> rule, bool? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, bool?> Required<TObject>(this IValitRule<TObject, bool?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleBooleanExtensions.cs
+++ b/src/Valit/ValitRuleBooleanExtensions.cs
@@ -1,3 +1,5 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleBooleanExtensions

--- a/src/Valit/ValitRuleByteExtensions.cs
+++ b/src/Valit/ValitRuleByteExtensions.cs
@@ -1,74 +1,76 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleByteExtensions
     {
         public static IValitRule<TObject, byte> IsGreaterThan<TObject>(this IValitRule<TObject, byte> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, byte> IsGreaterThan<TObject>(this IValitRule<TObject, byte> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, byte?> IsGreaterThan<TObject>(this IValitRule<TObject, byte?> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, byte?> IsGreaterThan<TObject>(this IValitRule<TObject, byte?> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, byte> IsLessThan<TObject>(this IValitRule<TObject, byte> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, byte> IsLessThan<TObject>(this IValitRule<TObject, byte> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, byte?> IsLessThan<TObject>(this IValitRule<TObject, byte?> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, byte?> IsLessThan<TObject>(this IValitRule<TObject, byte?> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, byte> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, byte> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, byte> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, byte> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, byte?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, byte?> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, byte?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, byte?> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, byte> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, byte> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, byte> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, byte> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, byte?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, byte?> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, byte?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, byte?> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, byte> IsEqualTo<TObject>(this IValitRule<TObject, byte> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, byte> IsEqualTo<TObject>(this IValitRule<TObject, byte> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, byte?> IsEqualTo<TObject>(this IValitRule<TObject, byte?> rule, byte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, byte?> IsEqualTo<TObject>(this IValitRule<TObject, byte?> rule, byte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, byte> IsNonZero<TObject>(this IValitRule<TObject, byte> rule) where TObject : class
-            => rule.Satisfies(p => p != 0);
+            => rule.Satisfies(p => p != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, byte?> IsNonZero<TObject>(this IValitRule<TObject, byte?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, byte?> Required<TObject>(this IValitRule<TObject, byte?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleDateTimeExtensions.cs
+++ b/src/Valit/ValitRuleDateTimeExtensions.cs
@@ -9,7 +9,7 @@ namespace Valit
             => rule.Satisfies(p => p > datetime).WithDefaultMessage(ErrorMessages.IsAfter, datetime);
 
         public static IValitRule<TObject, DateTime> IsAfter<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => datetime.HasValue && p > datetime.Value).WithDefaultMessage(ErrorMessages.IsAfter);
+            => rule.Satisfies(p => datetime.HasValue && p > datetime.Value).WithDefaultMessage(ErrorMessages.IsAfter, datetime);
 
         public static IValitRule<TObject, DateTime?> IsAfter<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
             => rule.Satisfies(p => p.HasValue && p.Value > datetime).WithDefaultMessage(ErrorMessages.IsAfter, datetime);

--- a/src/Valit/ValitRuleDateTimeExtensions.cs
+++ b/src/Valit/ValitRuleDateTimeExtensions.cs
@@ -1,94 +1,95 @@
 using System;
+using Valit.Errors;
 
 namespace Valit
 {
     public static class ValitRuleDateTimeExtensions
     {
         public static IValitRule<TObject, DateTime> IsAfter<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p > datetime);
+            => rule.Satisfies(p => p > datetime).WithDefaultMessage(ErrorMessages.IsAfter, datetime);
 
         public static IValitRule<TObject, DateTime> IsAfter<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => datetime.HasValue && p > datetime.Value);
+            => rule.Satisfies(p => datetime.HasValue && p > datetime.Value).WithDefaultMessage(ErrorMessages.IsAfter);
 
         public static IValitRule<TObject, DateTime?> IsAfter<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > datetime);
+            => rule.Satisfies(p => p.HasValue && p.Value > datetime).WithDefaultMessage(ErrorMessages.IsAfter, datetime);
 
         public static IValitRule<TObject, DateTime?> IsAfter<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value > datetime.Value);
+            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value > datetime.Value).WithDefaultMessage(ErrorMessages.IsAfter, datetime);
 
         public static IValitRule<TObject, DateTime> IsBefore<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p < datetime);
+            => rule.Satisfies(p => p < datetime).WithDefaultMessage(ErrorMessages.IsBefore, datetime);
 
         public static IValitRule<TObject, DateTime> IsBefore<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => datetime.HasValue && p < datetime.Value);
+            => rule.Satisfies(p => datetime.HasValue && p < datetime.Value).WithDefaultMessage(ErrorMessages.IsBefore, datetime);
 
         public static IValitRule<TObject, DateTime?> IsBefore<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < datetime);
+            => rule.Satisfies(p => p.HasValue && p.Value < datetime).WithDefaultMessage(ErrorMessages.IsBefore, datetime);
 
         public static IValitRule<TObject, DateTime?> IsBefore<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value < datetime.Value);
+            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value < datetime.Value).WithDefaultMessage(ErrorMessages.IsBefore, datetime);
 
         public static IValitRule<TObject, DateTime> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p >= datetime);
+            => rule.Satisfies(p => p >= datetime).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, datetime);
 
         public static IValitRule<TObject, DateTime> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => datetime.HasValue && p >= datetime.Value);
+            => rule.Satisfies(p => datetime.HasValue && p >= datetime.Value).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, datetime);
 
         public static IValitRule<TObject, DateTime?> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= datetime);
+            => rule.Satisfies(p => p.HasValue && p.Value >= datetime).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, datetime);
 
         public static IValitRule<TObject, DateTime?> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value >= datetime.Value);
+            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value >= datetime.Value).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, datetime);
 
         public static IValitRule<TObject, DateTime> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p <= datetime);
+            => rule.Satisfies(p => p <= datetime).WithDefaultMessage(ErrorMessages.IsBeforeOrSameAs, datetime);
 
         public static IValitRule<TObject, DateTime> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => datetime.HasValue && p <= datetime.Value);
+            => rule.Satisfies(p => datetime.HasValue && p <= datetime.Value).WithDefaultMessage(ErrorMessages.IsBeforeOrSameAs, datetime);
 
         public static IValitRule<TObject, DateTime?> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= datetime);
+            => rule.Satisfies(p => p.HasValue && p.Value <= datetime).WithDefaultMessage(ErrorMessages.IsBeforeOrSameAs, datetime);
 
         public static IValitRule<TObject, DateTime?> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value <= datetime.Value);
+            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value <= datetime.Value).WithDefaultMessage(ErrorMessages.IsBeforeOrSameAs, datetime);
 
         public static IValitRule<TObject, DateTime> IsAfterNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
-            => rule.Satisfies(p => p > DateTime.Now);
+            => rule.Satisfies(p => p > DateTime.Now).WithDefaultMessage(ErrorMessages.IsAfter, DateTime.Now);
 
         public static IValitRule<TObject, DateTime?> IsAfterNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > DateTime.Now);
+            => rule.Satisfies(p => p.HasValue && p.Value > DateTime.Now).WithDefaultMessage(ErrorMessages.IsAfter, DateTime.Now);
 
         public static IValitRule<TObject, DateTime> IsBeforeNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
-            => rule.Satisfies(p => p < DateTime.Now);
+            => rule.Satisfies(p => p < DateTime.Now).WithDefaultMessage(ErrorMessages.IsBefore, DateTime.Now);
 
         public static IValitRule<TObject, DateTime?> IsBeforeNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < DateTime.Now);
+            => rule.Satisfies(p => p.HasValue && p.Value < DateTime.Now).WithDefaultMessage(ErrorMessages.IsBefore, DateTime.Now);
 
         public static IValitRule<TObject, DateTime> IsAfterUtcNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
-            => rule.Satisfies(p => p > DateTime.UtcNow);
+            => rule.Satisfies(p => p > DateTime.UtcNow).WithDefaultMessage(ErrorMessages.IsAfter, DateTime.UtcNow);
 
         public static IValitRule<TObject, DateTime?> IsAfterUtcNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > DateTime.UtcNow);
+            => rule.Satisfies(p => p.HasValue && p.Value > DateTime.UtcNow).WithDefaultMessage(ErrorMessages.IsAfter, DateTime.UtcNow);
 
         public static IValitRule<TObject, DateTime> IsBeforeUtcNow<TObject>(this IValitRule<TObject, DateTime> rule) where TObject : class
-            => rule.Satisfies(p => p < DateTime.UtcNow);
+            => rule.Satisfies(p => p < DateTime.UtcNow).WithDefaultMessage(ErrorMessages.IsBefore, DateTime.UtcNow);
 
         public static IValitRule<TObject, DateTime?> IsBeforeUtcNow<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < DateTime.UtcNow);
+            => rule.Satisfies(p => p.HasValue && p.Value < DateTime.UtcNow).WithDefaultMessage(ErrorMessages.IsBefore, DateTime.UtcNow);
 
         public static IValitRule<TObject, DateTime> IsSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p == datetime);
+            => rule.Satisfies(p => p == datetime).WithDefaultMessage(ErrorMessages.IsSameAs, datetime);
 
         public static IValitRule<TObject, DateTime> IsSameAs<TObject>(this IValitRule<TObject, DateTime> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => datetime.HasValue && p == datetime.Value);
+            => rule.Satisfies(p => datetime.HasValue && p == datetime.Value).WithDefaultMessage(ErrorMessages.IsSameAs, datetime);
 
         public static IValitRule<TObject, DateTime?> IsSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == datetime);
+            => rule.Satisfies(p => p.HasValue && p.Value == datetime).WithDefaultMessage(ErrorMessages.IsSameAs, datetime);
 
         public static IValitRule<TObject, DateTime?> IsSameAs<TObject>(this IValitRule<TObject, DateTime?> rule, DateTime? datetime) where TObject : class
-            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value == datetime.Value);
+            => rule.Satisfies(p => p.HasValue && datetime.HasValue && p.Value == datetime.Value).WithDefaultMessage(ErrorMessages.IsSameAs, datetime);
 
         public static IValitRule<TObject, DateTime?> Required<TObject>(this IValitRule<TObject, DateTime?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleDateTimeOffsetExtensions.cs
+++ b/src/Valit/ValitRuleDateTimeOffsetExtensions.cs
@@ -1,94 +1,95 @@
 using System;
+using Valit.Errors;
 
 namespace Valit
 {
     public static class ValitRuleDateTimeOffsetExtensions
     {
         public static IValitRule<TObject, DateTimeOffset> IsAfter<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p > dateTimeOffset);
+            => rule.Satisfies(p => p > dateTimeOffset).WithDefaultMessage(ErrorMessages.IsAfter, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsAfter<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => dateTimeOffset.HasValue && p > dateTimeOffset.Value);
+            => rule.Satisfies(p => dateTimeOffset.HasValue && p > dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsAfter<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > dateTimeOffset);
+            => rule.Satisfies(p => p.HasValue && p.Value > dateTimeOffset).WithDefaultMessage(ErrorMessages.IsAfter, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsAfter<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value > dateTimeOffset.Value);
+            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value > dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsBefore<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p < dateTimeOffset);
+            => rule.Satisfies(p => p < dateTimeOffset).WithDefaultMessage(ErrorMessages.IsBefore, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsBefore<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => dateTimeOffset.HasValue && p < dateTimeOffset.Value);
+            => rule.Satisfies(p => dateTimeOffset.HasValue && p < dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsBefore, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsBefore<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < dateTimeOffset);
+            => rule.Satisfies(p => p.HasValue && p.Value < dateTimeOffset).WithDefaultMessage(ErrorMessages.IsBefore, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsBefore<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value < dateTimeOffset.Value);
+            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value < dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsBefore, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p >= dateTimeOffset);
+            => rule.Satisfies(p => p >= dateTimeOffset).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => dateTimeOffset.HasValue && p >= dateTimeOffset.Value);
+            => rule.Satisfies(p => dateTimeOffset.HasValue && p >= dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= dateTimeOffset);
+            => rule.Satisfies(p => p.HasValue && p.Value >= dateTimeOffset).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsAfterOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value >= dateTimeOffset.Value);
+            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value >= dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsAfterOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p <= dateTimeOffset);
+            => rule.Satisfies(p => p <= dateTimeOffset).WithDefaultMessage(ErrorMessages.IsBeforeOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => dateTimeOffset.HasValue && p <= dateTimeOffset.Value);
+            => rule.Satisfies(p => dateTimeOffset.HasValue && p <= dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsBeforeOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= dateTimeOffset);
+            => rule.Satisfies(p => p.HasValue && p.Value <= dateTimeOffset).WithDefaultMessage(ErrorMessages.IsBeforeOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsBeforeOrSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value <= dateTimeOffset.Value);
+            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value <= dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsBeforeOrSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsAfterNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
-            => rule.Satisfies(p => p > DateTimeOffset.Now);
+            => rule.Satisfies(p => p > DateTimeOffset.Now).WithDefaultMessage(ErrorMessages.IsAfter, DateTime.Now);
 
         public static IValitRule<TObject, DateTimeOffset?> IsAfterNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > DateTimeOffset.Now);
+            => rule.Satisfies(p => p.HasValue && p.Value > DateTimeOffset.Now).WithDefaultMessage(ErrorMessages.IsAfter, DateTime.Now);
 
         public static IValitRule<TObject, DateTimeOffset> IsBeforeNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
-            => rule.Satisfies(p => p < DateTimeOffset.Now);
+            => rule.Satisfies(p => p < DateTimeOffset.Now).WithDefaultMessage(ErrorMessages.IsBefore, DateTime.Now);
 
         public static IValitRule<TObject, DateTimeOffset?> IsBeforeNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < DateTimeOffset.Now);
+            => rule.Satisfies(p => p.HasValue && p.Value < DateTimeOffset.Now).WithDefaultMessage(ErrorMessages.IsBefore, DateTime.Now);
 
         public static IValitRule<TObject, DateTimeOffset> IsAfterUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
-            => rule.Satisfies(p => p > DateTimeOffset.UtcNow);
+            => rule.Satisfies(p => p > DateTimeOffset.UtcNow).WithDefaultMessage(ErrorMessages.IsAfter, DateTime.UtcNow);
 
         public static IValitRule<TObject, DateTimeOffset?> IsAfterUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > DateTimeOffset.UtcNow);
+            => rule.Satisfies(p => p.HasValue && p.Value > DateTimeOffset.UtcNow).WithDefaultMessage(ErrorMessages.IsAfter, DateTime.UtcNow);
 
         public static IValitRule<TObject, DateTimeOffset> IsBeforeUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset> rule) where TObject : class
-            => rule.Satisfies(p => p < DateTimeOffset.UtcNow);
+            => rule.Satisfies(p => p < DateTimeOffset.UtcNow).WithDefaultMessage(ErrorMessages.IsBefore, DateTime.UtcNow);
 
         public static IValitRule<TObject, DateTimeOffset?> IsBeforeUtcNow<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < DateTimeOffset.UtcNow);
+            => rule.Satisfies(p => p.HasValue && p.Value < DateTimeOffset.UtcNow).WithDefaultMessage(ErrorMessages.IsBefore, DateTime.UtcNow);
 
         public static IValitRule<TObject, DateTimeOffset> IsSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p == dateTimeOffset);
+            => rule.Satisfies(p => p == dateTimeOffset).WithDefaultMessage(ErrorMessages.IsSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset> IsSameAs<TObject>(this IValitRule<TObject, DateTimeOffset> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => dateTimeOffset.HasValue && p == dateTimeOffset.Value);
+            => rule.Satisfies(p => dateTimeOffset.HasValue && p == dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == dateTimeOffset);
+            => rule.Satisfies(p => p.HasValue && p.Value == dateTimeOffset).WithDefaultMessage(ErrorMessages.IsSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> IsSameAs<TObject>(this IValitRule<TObject, DateTimeOffset?> rule, DateTimeOffset? dateTimeOffset) where TObject : class
-            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value == dateTimeOffset.Value);
+            => rule.Satisfies(p => p.HasValue && dateTimeOffset.HasValue && p.Value == dateTimeOffset.Value).WithDefaultMessage(ErrorMessages.IsSameAs, dateTimeOffset);
 
         public static IValitRule<TObject, DateTimeOffset?> Required<TObject>(this IValitRule<TObject, DateTimeOffset?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleDecimalExtensions.cs
+++ b/src/Valit/ValitRuleDecimalExtensions.cs
@@ -1,87 +1,89 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleDecimalExtensions
     {
         public static IValitRule<TObject, decimal> IsGreaterThan<TObject>(this IValitRule<TObject, decimal> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, decimal> IsGreaterThan<TObject>(this IValitRule<TObject, decimal> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, decimal?> IsGreaterThan<TObject>(this IValitRule<TObject, decimal?> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, decimal?> IsGreaterThan<TObject>(this IValitRule<TObject, decimal?> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, decimal> IsLessThan<TObject>(this IValitRule<TObject, decimal> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, decimal> IsLessThan<TObject>(this IValitRule<TObject, decimal> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, decimal?> IsLessThan<TObject>(this IValitRule<TObject, decimal?> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, decimal?> IsLessThan<TObject>(this IValitRule<TObject, decimal?> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, decimal> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, decimal> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, decimal> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, decimal> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, decimal?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, decimal?> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, decimal?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, decimal?> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, decimal> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, decimal> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, decimal> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, decimal> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, decimal?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, decimal?> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, decimal?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, decimal?> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, decimal> IsEqualTo<TObject>(this IValitRule<TObject, decimal> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, decimal> IsEqualTo<TObject>(this IValitRule<TObject, decimal> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, decimal?> IsEqualTo<TObject>(this IValitRule<TObject, decimal?> rule, decimal value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, decimal?> IsEqualTo<TObject>(this IValitRule<TObject, decimal?> rule, decimal? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, decimal> IsPositive<TObject>(this IValitRule<TObject, decimal> rule) where TObject : class
-            => rule.Satisfies(p => p > 0m);
+            => rule.Satisfies(p => p > 0m).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, decimal?> IsPositive<TObject>(this IValitRule<TObject, decimal?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > 0m);
+            => rule.Satisfies(p => p.HasValue && p.Value > 0m).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, decimal> IsNegative<TObject>(this IValitRule<TObject, decimal> rule) where TObject : class
-            => rule.Satisfies(p => p < 0m);
+            => rule.Satisfies(p => p < 0m).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, decimal?> IsNegative<TObject>(this IValitRule<TObject, decimal?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < 0m);
+            => rule.Satisfies(p => p.HasValue && p.Value < 0m).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, decimal> IsNonZero<TObject>(this IValitRule<TObject, decimal> rule) where TObject : class
-            => rule.Satisfies(p => p != 0m);
+            => rule.Satisfies(p => p != 0m).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, decimal?> IsNonZero<TObject>(this IValitRule<TObject, decimal?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0m);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0m).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, decimal?> Required<TObject>(this IValitRule<TObject, decimal?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
 
     }
 }

--- a/src/Valit/ValitRuleDoubleExtensions.cs
+++ b/src/Valit/ValitRuleDoubleExtensions.cs
@@ -1,100 +1,101 @@
 using System;
+using Valit.Errors;
 
 namespace Valit
 {
     public static class ValitRuleDoubleExtensions
     {
         public static IValitRule<TObject, double> IsGreaterThan<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p > value);
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, double> IsGreaterThan<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, double?> IsGreaterThan<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, double?> IsGreaterThan<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, double> IsLessThan<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && value > p);
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, double> IsLessThan<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && value.Value > p);
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && value.Value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, double?> IsLessThan<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && value > p.Value);
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, double?> IsLessThan<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && value.Value > p.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && value.Value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, double> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p >= value);
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, double> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, double?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, double?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, double> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p <= value);
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, double> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, double?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, double?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, double> IsEqualTo<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p == value);
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, double> IsEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, double?> IsEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, double?> IsEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, double> IsPositive<TObject>(this IValitRule<TObject, double> rule) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && p > 0d);
+            => rule.Satisfies(p => !Double.IsNaN(p) && p > 0d).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, double?> IsPositive<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value > 0d);
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value > 0d).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, double> IsNegative<TObject>(this IValitRule<TObject, double> rule) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && p < 0d);
+            => rule.Satisfies(p => !Double.IsNaN(p) && p < 0d).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, double?> IsNegative<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value < 0d);
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value < 0d).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, double> IsNonZero<TObject>(this IValitRule<TObject, double> rule) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && p != 0d);
+            => rule.Satisfies(p => !Double.IsNaN(p) && p != 0d).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, double?> IsNonZero<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value != 0d);
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value != 0d).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, double> IsNumber<TObject>(this IValitRule<TObject, double> rule) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p));
+            => rule.Satisfies(p => !Double.IsNaN(p)).WithDefaultMessage(ErrorMessages.IsNumber);
 
         public static IValitRule<TObject, double?> IsNumber<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value));
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value)).WithDefaultMessage(ErrorMessages.IsNumber);
 
         public static IValitRule<TObject, double> IsNaN<TObject>(this IValitRule<TObject, double> rule) where TObject : class
-            => rule.Satisfies(p => Double.IsNaN(p));
+            => rule.Satisfies(p => Double.IsNaN(p)).WithDefaultMessage(ErrorMessages.IsNaN);
 
         public static IValitRule<TObject, double?> IsNaN<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && Double.IsNaN(p.Value));
+            => rule.Satisfies(p => p.HasValue && Double.IsNaN(p.Value)).WithDefaultMessage(ErrorMessages.IsNaN);
 
         public static IValitRule<TObject, double?> Required<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleEnumerableExtensions.cs
+++ b/src/Valit/ValitRuleEnumerableExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Valit.Errors;
 
 namespace Valit
 {
@@ -7,9 +8,9 @@ namespace Valit
     {
 
         public static IValitRule<TObject, IEnumerable<TProperty>> MinItems<TObject, TProperty>(this IValitRule<TObject, IEnumerable<TProperty>> rule, int expectedItemsNumber) where TObject : class
-            => rule.Satisfies(p => p != null && p.Count() >= expectedItemsNumber);
+            => rule.Satisfies(p => p != null && p.Count() >= expectedItemsNumber).WithDefaultMessage(ErrorMessages.MinItems, expectedItemsNumber);
 
         public static IValitRule<TObject, IEnumerable<TProperty>> MaxItems<TObject, TProperty>(this IValitRule<TObject, IEnumerable<TProperty>> rule, int expectedItemsNumber) where TObject : class
-            => rule.Satisfies(p => p != null && p.Count() <= expectedItemsNumber);
+            => rule.Satisfies(p => p != null && p.Count() <= expectedItemsNumber).WithDefaultMessage(ErrorMessages.MaxItems, expectedItemsNumber);
     }
 }

--- a/src/Valit/ValitRuleFloatExtensions.cs
+++ b/src/Valit/ValitRuleFloatExtensions.cs
@@ -1,100 +1,101 @@
 using System;
+using Valit.Errors;
 
 namespace Valit
 {
     public static class ValitRuleFloatExtensions
     {
         public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p > value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && value > p);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && value.Value > p);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && value.Value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && value > p.Value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && value.Value > p.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && value.Value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p >= value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p <= value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p == value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float> IsPositive<TObject>(this IValitRule<TObject, float> rule) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && p > 0f);
+            => rule.Satisfies(p => !Single.IsNaN(p) && p > 0f).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, float?> IsPositive<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value > 0f);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value > 0f).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, float> IsNegative<TObject>(this IValitRule<TObject, float> rule) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && p < 0f);
+            => rule.Satisfies(p => !Single.IsNaN(p) && p < 0f).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, float?> IsNegative<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value < 0f);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value < 0f).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, float> IsNonZero<TObject>(this IValitRule<TObject, float> rule) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && p != 0f);
+            => rule.Satisfies(p => !Single.IsNaN(p) && p != 0f).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, float?> IsNonZero<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value != 0f);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value != 0f).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, float> IsNumber<TObject>(this IValitRule<TObject, float> rule) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p));
+            => rule.Satisfies(p => !Single.IsNaN(p)).WithDefaultMessage(ErrorMessages.IsNumber);
 
         public static IValitRule<TObject, float?> IsNumber<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value));
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value)).WithDefaultMessage(ErrorMessages.IsNumber);
 
         public static IValitRule<TObject, float> IsNaN<TObject>(this IValitRule<TObject, float> rule) where TObject : class
-            => rule.Satisfies(p => Single.IsNaN(p));
+            => rule.Satisfies(p => Single.IsNaN(p)).WithDefaultMessage(ErrorMessages.IsNaN);
 
         public static IValitRule<TObject, float?> IsNaN<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && Single.IsNaN(p.Value));
+            => rule.Satisfies(p => p.HasValue && Single.IsNaN(p.Value)).WithDefaultMessage(ErrorMessages.IsNaN);
 
         public static IValitRule<TObject, float?> Required<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleGuidExtensions.cs
+++ b/src/Valit/ValitRuleGuidExtensions.cs
@@ -1,28 +1,29 @@
 using System;
+using Valit.Errors;
 
 namespace Valit
 {
     public static class ValitRuleGuidExtensions
     {
-        public static IValitRule<TObject, Guid> IsEqualTo<TObject>(this IValitRule<TObject, Guid> rule, Guid guid) where TObject : class
-            => rule.Satisfies(p => p == guid);
+        public static IValitRule<TObject, Guid> IsEqualTo<TObject>(this IValitRule<TObject, Guid> rule, Guid value) where TObject : class
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, Guid> IsEqualTo<TObject>(this IValitRule<TObject, Guid> rule, Guid? guid) where TObject : class
-            => rule.Satisfies(p => guid.HasValue && p == guid.Value);
+        public static IValitRule<TObject, Guid> IsEqualTo<TObject>(this IValitRule<TObject, Guid> rule, Guid? value) where TObject : class
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, Guid?> IsEqualTo<TObject>(this IValitRule<TObject, Guid?> rule, Guid? guid) where TObject : class
-            => rule.Satisfies(p => p.HasValue && guid.HasValue && p.Value == guid.Value);
+        public static IValitRule<TObject, Guid?> IsEqualTo<TObject>(this IValitRule<TObject, Guid?> rule, Guid? value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, Guid?> IsEqualTo<TObject>(this IValitRule<TObject, Guid?> rule, Guid guid) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == guid);
+        public static IValitRule<TObject, Guid?> IsEqualTo<TObject>(this IValitRule<TObject, Guid?> rule, Guid value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, Guid?> Required<TObject>(this IValitRule<TObject, Guid?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
 
         public static IValitRule<TObject, Guid> IsNotEmpty<TObject>(this IValitRule<TObject, Guid> rule) where TObject : class
-            => rule.Satisfies(p => p != Guid.Empty);
+            => rule.Satisfies(p => p != Guid.Empty).WithDefaultMessage(ErrorMessages.IsNotEmpty);
 
         public static IValitRule<TObject, Guid?> IsNotEmpty<TObject>(this IValitRule<TObject, Guid?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != Guid.Empty);
+            => rule.Satisfies(p => p.HasValue && p.Value != Guid.Empty).WithDefaultMessage(ErrorMessages.IsNotEmpty);
     }
 }

--- a/src/Valit/ValitRuleInt16Extensions.cs
+++ b/src/Valit/ValitRuleInt16Extensions.cs
@@ -1,86 +1,88 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleInt16Extensions
     {
         public static IValitRule<TObject, short> IsGreaterThan<TObject>(this IValitRule<TObject, short> rule, short value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, short> IsGreaterThan<TObject>(this IValitRule<TObject, short> rule, short? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, short?> IsGreaterThan<TObject>(this IValitRule<TObject, short?> rule, short value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, short?> IsGreaterThan<TObject>(this IValitRule<TObject, short?> rule, short? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, short> IsLessThan<TObject>(this IValitRule<TObject, short> rule, short value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, short> IsLessThan<TObject>(this IValitRule<TObject, short> rule, short? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, short?> IsLessThan<TObject>(this IValitRule<TObject, short?> rule, short value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, short?> IsLessThan<TObject>(this IValitRule<TObject, short?> rule, short? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, short> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, short> rule, short value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, short> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, short> rule, short? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, short?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, short?> rule, short value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, short?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, short?> rule, short? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, short> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, short> rule, short value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, short> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, short> rule, short? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, short?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, short?> rule, short value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, short?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, short?> rule, short? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, short> IsEqualTo<TObject>(this IValitRule<TObject, short> rule, short value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, short> IsEqualTo<TObject>(this IValitRule<TObject, short> rule, short? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, short?> IsEqualTo<TObject>(this IValitRule<TObject, short?> rule, short value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, short?> IsEqualTo<TObject>(this IValitRule<TObject, short?> rule, short? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, short> IsPositive<TObject>(this IValitRule<TObject, short> rule) where TObject : class
-            => rule.Satisfies(p => p > 0);
+            => rule.Satisfies(p => p > 0).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, short?> IsPositive<TObject>(this IValitRule<TObject, short?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > 0);
+            => rule.Satisfies(p => p.HasValue && p.Value > 0).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, short> IsNegative<TObject>(this IValitRule<TObject, short> rule) where TObject : class
-            => rule.Satisfies(p => p < 0);
+            => rule.Satisfies(p => p < 0).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, short?> IsNegative<TObject>(this IValitRule<TObject, short?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < 0);
+            => rule.Satisfies(p => p.HasValue && p.Value < 0).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, short> IsNonZero<TObject>(this IValitRule<TObject, short> rule) where TObject : class
-            => rule.Satisfies(p => p != 0);
+            => rule.Satisfies(p => p != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, short?> IsNonZero<TObject>(this IValitRule<TObject, short?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, short?> Required<TObject>(this IValitRule<TObject, short?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleInt32Extensions.cs
+++ b/src/Valit/ValitRuleInt32Extensions.cs
@@ -1,86 +1,88 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleInt32Extensions
     {
         public static IValitRule<TObject, int> IsGreaterThan<TObject>(this IValitRule<TObject, int> rule, int value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, int> IsGreaterThan<TObject>(this IValitRule<TObject, int> rule, int? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, int?> IsGreaterThan<TObject>(this IValitRule<TObject, int?> rule, int value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, int?> IsGreaterThan<TObject>(this IValitRule<TObject, int?> rule, int? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, int> IsLessThan<TObject>(this IValitRule<TObject, int> rule, int value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, int> IsLessThan<TObject>(this IValitRule<TObject, int> rule, int? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, int?> IsLessThan<TObject>(this IValitRule<TObject, int?> rule, int value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, int?> IsLessThan<TObject>(this IValitRule<TObject, int?> rule, int? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, int> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, int> rule, int value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, int> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, int> rule, int? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, int?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, int?> rule, int value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, int?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, int?> rule, int? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, int> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, int> rule, int value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, int> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, int> rule, int? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, int?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, int?> rule, int value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, int?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, int?> rule, int? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, int> IsEqualTo<TObject>(this IValitRule<TObject, int> rule, int value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, int> IsEqualTo<TObject>(this IValitRule<TObject, int> rule, int? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, int?> IsEqualTo<TObject>(this IValitRule<TObject, int?> rule, int value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, int?> IsEqualTo<TObject>(this IValitRule<TObject, int?> rule, int? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, int> IsPositive<TObject>(this IValitRule<TObject, int> rule) where TObject : class
-            => rule.Satisfies(p => p > 0);
+            => rule.Satisfies(p => p > 0).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, int?> IsPositive<TObject>(this IValitRule<TObject, int?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > 0);
+            => rule.Satisfies(p => p.HasValue && p.Value > 0).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, int> IsNegative<TObject>(this IValitRule<TObject, int> rule) where TObject : class
-            => rule.Satisfies(p => p < 0);
+            => rule.Satisfies(p => p < 0).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, int?> IsNegative<TObject>(this IValitRule<TObject, int?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < 0);
+            => rule.Satisfies(p => p.HasValue && p.Value < 0).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, int> IsNonZero<TObject>(this IValitRule<TObject, int> rule) where TObject : class
-            => rule.Satisfies(p => p != 0);
+            => rule.Satisfies(p => p != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, int?> IsNonZero<TObject>(this IValitRule<TObject, int?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, int?> Required<TObject>(this IValitRule<TObject, int?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleInt64Extensions.cs
+++ b/src/Valit/ValitRuleInt64Extensions.cs
@@ -1,96 +1,98 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleInt64Extensions
     {
         public static IValitRule<TObject, long> IsGreaterThan<TObject>(this IValitRule<TObject, long> rule, long value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, long> IsGreaterThan<TObject>(this IValitRule<TObject, long> rule, long? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, long?> IsGreaterThan<TObject>(this IValitRule<TObject, long?> rule, long value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, long?> IsGreaterThan<TObject>(this IValitRule<TObject, long?> rule, long? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, long> IsLessThan<TObject>(this IValitRule<TObject, long> rule, long value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, long> IsLessThan<TObject>(this IValitRule<TObject, long> rule, long? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, long?> IsLessThan<TObject>(this IValitRule<TObject, long?> rule, long value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, long?> IsLessThan<TObject>(this IValitRule<TObject, long?> rule, long? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, long> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, long> rule, long value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, long> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, long> rule, long? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, long?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, long?> rule, long value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, long?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, long?> rule, long? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, long> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, long> rule, long value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, long> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, long> rule, long? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, long?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, long?> rule, long value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, long?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, long?> rule, long? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, long> IsEqualTo<TObject>(this IValitRule<TObject, long> rule, long value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, long> IsEqualTo<TObject>(this IValitRule<TObject, long> rule, long? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, long?> IsEqualTo<TObject>(this IValitRule<TObject, long?> rule, long value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, long?> IsEqualTo<TObject>(this IValitRule<TObject, long?> rule, long? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, long> IsPositive<TObject>(this IValitRule<TObject, long> rule) where TObject : class
-            => rule.Satisfies(p => p > 0L);
+            => rule.Satisfies(p => p > 0L).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, long?> IsPositive<TObject>(this IValitRule<TObject, long?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > 0L);
+            => rule.Satisfies(p => p.HasValue && p.Value > 0L).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, long> IsNegative<TObject>(this IValitRule<TObject, long> rule) where TObject : class
-            => rule.Satisfies(p => p < 0L);
+            => rule.Satisfies(p => p < 0L).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, long?> IsNegative<TObject>(this IValitRule<TObject, long?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < 0L);
+            => rule.Satisfies(p => p.HasValue && p.Value < 0L).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, long> IsNonZero<TObject>(this IValitRule<TObject, long> rule) where TObject : class
-            => rule.Satisfies(p => p != 0L);
+            => rule.Satisfies(p => p != 0L).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, long?> IsNonZero<TObject>(this IValitRule<TObject, long?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0L);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0L).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, long?> Required<TObject>(this IValitRule<TObject, long?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRulePropertyExtensions.cs
+++ b/src/Valit/ValitRulePropertyExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using Valit.Errors;
 using Valit.Exceptions;
 using Valit.Rules;
@@ -105,7 +107,14 @@ namespace Valit
 
         internal static IValitRule<TObject, TProperty> WithDefaultMessage<TObject, TProperty>(this IValitRule<TObject, TProperty> rule, string message, params object[] @params) where TObject : class
         {
-            var formattedMessage = string.Format(message, @params);
+            var accessor = rule.GetAccessor();
+            var memberExpression = accessor.PropertySelector.Body as MemberExpression;
+
+            memberExpression.ThrowIfNull("Given property selector is null");
+
+            var messageParams = new [] { memberExpression.Member.Name }.Concat(@params).ToArray();
+            var formattedMessage = string.Format(message, messageParams);
+            
             return rule.WithMessage(formattedMessage);
         }
 

--- a/src/Valit/ValitRulePropertyExtensions.cs
+++ b/src/Valit/ValitRulePropertyExtensions.cs
@@ -103,6 +103,12 @@ namespace Valit
             return rule;
         }
 
+        internal static IValitRule<TObject, TProperty> WithDefaultMessage<TObject, TProperty>(this IValitRule<TObject, TProperty> rule, string message, params object[] @params) where TObject : class
+        {
+            var formattedMessage = string.Format(message, @params);
+            return rule.WithMessage(formattedMessage);
+        }
+
         internal static IEnumerable<IValitRule<TObject>> GetAllEnsureRules<TObject, TProperty>(this IValitRule<TObject, TProperty> rule) where TObject : class
         {
             var rules = new List<IValitRule<TObject>> { rule };

--- a/src/Valit/ValitRulePropertyExtensions.cs
+++ b/src/Valit/ValitRulePropertyExtensions.cs
@@ -27,7 +27,8 @@ namespace Valit
             var newRule = new ValitRule<TObject, TProperty>(rule);
             accessor = newRule.GetAccessor();
             accessor.SetPredicate(predicate);
-            return newRule;
+            
+            return newRule.WithDefaultMessage(ErrorMessages.Satisifes);
         }
 
         public static IValitRule<TObject, TProperty> Required<TObject, TProperty>(this IValitRule<TObject, TProperty> rule) where TObject : class where TProperty : class

--- a/src/Valit/ValitRuleSByteExtensions.cs
+++ b/src/Valit/ValitRuleSByteExtensions.cs
@@ -1,96 +1,98 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleSByteExtensions
     {
         public static IValitRule<TObject, sbyte> IsGreaterThan<TObject>(this IValitRule<TObject, sbyte> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, sbyte> IsGreaterThan<TObject>(this IValitRule<TObject, sbyte> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, sbyte?> IsGreaterThan<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, sbyte?> IsGreaterThan<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, sbyte> IsLessThan<TObject>(this IValitRule<TObject, sbyte> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, sbyte> IsLessThan<TObject>(this IValitRule<TObject, sbyte> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, sbyte?> IsLessThan<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, sbyte?> IsLessThan<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, sbyte> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, sbyte> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, sbyte> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, sbyte> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, sbyte?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, sbyte?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, sbyte> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, sbyte> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, sbyte> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, sbyte> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, sbyte?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, sbyte?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, sbyte> IsEqualTo<TObject>(this IValitRule<TObject, sbyte> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, sbyte> IsEqualTo<TObject>(this IValitRule<TObject, sbyte> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, sbyte?> IsEqualTo<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, sbyte?> IsEqualTo<TObject>(this IValitRule<TObject, sbyte?> rule, sbyte? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, sbyte> IsPositive<TObject>(this IValitRule<TObject, sbyte> rule) where TObject : class
-            => rule.Satisfies(p => p > 0);
+            => rule.Satisfies(p => p > 0).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, sbyte?> IsPositive<TObject>(this IValitRule<TObject, sbyte?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > 0);
+            => rule.Satisfies(p => p.HasValue && p.Value > 0).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, sbyte> IsNegative<TObject>(this IValitRule<TObject, sbyte> rule) where TObject : class
-            => rule.Satisfies(p => p < 0);
+            => rule.Satisfies(p => p < 0).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, sbyte?> IsNegative<TObject>(this IValitRule<TObject, sbyte?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < 0);
+            => rule.Satisfies(p => p.HasValue && p.Value < 0).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, sbyte> IsNonZero<TObject>(this IValitRule<TObject, sbyte> rule) where TObject : class
-            => rule.Satisfies(p => p != 0);
+            => rule.Satisfies(p => p != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, sbyte?> IsNonZero<TObject>(this IValitRule<TObject, sbyte?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, sbyte?> Required<TObject>(this IValitRule<TObject, sbyte?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleStringExtensions.cs
+++ b/src/Valit/ValitRuleStringExtensions.cs
@@ -1,26 +1,28 @@
 using System;
 using System.Text.RegularExpressions;
+using Valit.Errors;
 
 namespace Valit
 {
     public static class ValitRuleStringExtensions
     {
+        private static string _emailRegularExpression => @"\A(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\Z";
         public static IValitRule<TObject, string> IsEqualTo<TObject>(this IValitRule<TObject, string> rule, string value) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && !String.IsNullOrEmpty(value) && p == value);
+            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && !String.IsNullOrEmpty(value) && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, string> MinLength<TObject>(this IValitRule<TObject, string> rule, int length) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && p.Length >= length);
+            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && p.Length >= length).WithDefaultMessage(ErrorMessages.MinLength, length);
 
         public static IValitRule<TObject, string> MaxLength<TObject>(this IValitRule<TObject, string> rule, int length) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && p.Length <= length);
+            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && p.Length <= length).WithDefaultMessage(ErrorMessages.MaxLength, length);
 
         public static IValitRule<TObject, string> Matches<TObject>(this IValitRule<TObject, string> rule, string regularExpression) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && !String.IsNullOrEmpty(regularExpression) && Regex.IsMatch(p, regularExpression));
+            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && !String.IsNullOrEmpty(regularExpression) && Regex.IsMatch(p, regularExpression)).WithDefaultMessage(ErrorMessages.Matches, regularExpression);
 
         public static IValitRule<TObject, string> Email<TObject>(this IValitRule<TObject, string> rule) where TObject : class
-            => rule.Matches(@"\A(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\Z");
+            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && !String.IsNullOrEmpty(_emailRegularExpression) && Regex.IsMatch(p, _emailRegularExpression)).WithDefaultMessage(ErrorMessages.Email);
 
         public static IValitRule<TObject, string> Required<TObject>(this IValitRule<TObject, string> rule) where TObject : class
-            => rule.Satisfies(p => !string.IsNullOrEmpty(p));
+            => rule.Satisfies(p => !string.IsNullOrEmpty(p)).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleTimeSpanExtensions.cs
+++ b/src/Valit/ValitRuleTimeSpanExtensions.cs
@@ -1,76 +1,77 @@
 using System;
+using Valit.Errors;
 
 namespace Valit
 {
     public static class ValitRuleTimeSpanExtensions
     {
-        public static IValitRule<TObject, TimeSpan> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p > TimeSpan);
+        public static IValitRule<TObject, TimeSpan> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, TimeSpan> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => TimeSpan.HasValue && p > TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > TimeSpan);
+        public static IValitRule<TObject, TimeSpan?> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value > TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan?> IsGreaterThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, TimeSpan> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p < TimeSpan);
+        public static IValitRule<TObject, TimeSpan> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, TimeSpan> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => TimeSpan.HasValue && p < TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < TimeSpan);
+        public static IValitRule<TObject, TimeSpan?> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value < TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan?> IsLessThan<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, TimeSpan> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p >= TimeSpan);
+        public static IValitRule<TObject, TimeSpan> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => TimeSpan.HasValue && p >= TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= TimeSpan);
+        public static IValitRule<TObject, TimeSpan?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value >= TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p <= TimeSpan);
+        public static IValitRule<TObject, TimeSpan> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => TimeSpan.HasValue && p <= TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= TimeSpan);
+        public static IValitRule<TObject, TimeSpan?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value <= TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p == TimeSpan);
+        public static IValitRule<TObject, TimeSpan> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => TimeSpan.HasValue && p == TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == TimeSpan);
+        public static IValitRule<TObject, TimeSpan?> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, TimeSpan?> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? TimeSpan) where TObject : class
-            => rule.Satisfies(p => p.HasValue && TimeSpan.HasValue && p.Value == TimeSpan.Value);
+        public static IValitRule<TObject, TimeSpan?> IsEqualTo<TObject>(this IValitRule<TObject, TimeSpan?> rule, TimeSpan? value) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, TimeSpan> IsNonZero<TObject>(this IValitRule<TObject, TimeSpan> rule) where TObject : class
-            => rule.Satisfies(p => p != TimeSpan.Zero);
+            => rule.Satisfies(p => p != TimeSpan.Zero).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, TimeSpan?> IsNonZero<TObject>(this IValitRule<TObject, TimeSpan?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != TimeSpan.Zero);
+            => rule.Satisfies(p => p.HasValue && p.Value != TimeSpan.Zero).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, TimeSpan?> Required<TObject>(this IValitRule<TObject, TimeSpan?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleUInt16Extensions.cs
+++ b/src/Valit/ValitRuleUInt16Extensions.cs
@@ -1,83 +1,85 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleUInt16Extensions
     {
         public static IValitRule<TObject, ushort> IsGreaterThan<TObject>(this IValitRule<TObject, ushort> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, ushort> IsGreaterThan<TObject>(this IValitRule<TObject, ushort> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, ushort?> IsGreaterThan<TObject>(this IValitRule<TObject, ushort?> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, ushort?> IsGreaterThan<TObject>(this IValitRule<TObject, ushort?> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, ushort> IsLessThan<TObject>(this IValitRule<TObject, ushort> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, ushort> IsLessThan<TObject>(this IValitRule<TObject, ushort> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, ushort?> IsLessThan<TObject>(this IValitRule<TObject, ushort?> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, ushort?> IsLessThan<TObject>(this IValitRule<TObject, ushort?> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, ushort> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, ushort> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, ushort> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, ushort> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, ushort?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, ushort?> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, ushort?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, ushort?> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, ushort> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, ushort> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, ushort> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, ushort> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, ushort?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, ushort?> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, ushort?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, ushort?> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, ushort> IsEqualTo<TObject>(this IValitRule<TObject, ushort> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, ushort> IsEqualTo<TObject>(this IValitRule<TObject, ushort> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, ushort?> IsEqualTo<TObject>(this IValitRule<TObject, ushort?> rule, ushort value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, ushort?> IsEqualTo<TObject>(this IValitRule<TObject, ushort?> rule, ushort? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, ushort> IsNonZero<TObject>(this IValitRule<TObject, ushort> rule) where TObject : class
-            => rule.Satisfies(p => p != 0);
+            => rule.Satisfies(p => p != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, ushort?> IsNonZero<TObject>(this IValitRule<TObject, ushort?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, ushort?> Required<TObject>(this IValitRule<TObject, ushort?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleUInt32Extensions.cs
+++ b/src/Valit/ValitRuleUInt32Extensions.cs
@@ -1,84 +1,86 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleUInt32Extensions
     {
         public static IValitRule<TObject, uint> IsGreaterThan<TObject>(this IValitRule<TObject, uint> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, uint> IsGreaterThan<TObject>(this IValitRule<TObject, uint> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, uint?> IsGreaterThan<TObject>(this IValitRule<TObject, uint?> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, uint?> IsGreaterThan<TObject>(this IValitRule<TObject, uint?> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, uint> IsLessThan<TObject>(this IValitRule<TObject, uint> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, uint> IsLessThan<TObject>(this IValitRule<TObject, uint> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, uint?> IsLessThan<TObject>(this IValitRule<TObject, uint?> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, uint?> IsLessThan<TObject>(this IValitRule<TObject, uint?> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, uint> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, uint> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, uint> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, uint> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, uint?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, uint?> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, uint?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, uint?> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, uint> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, uint> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, uint> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, uint> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, uint?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, uint?> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, uint?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, uint?> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, uint> IsEqualTo<TObject>(this IValitRule<TObject, uint> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, uint> IsEqualTo<TObject>(this IValitRule<TObject, uint> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, uint?> IsEqualTo<TObject>(this IValitRule<TObject, uint?> rule, uint value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, uint?> IsEqualTo<TObject>(this IValitRule<TObject, uint?> rule, uint? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, uint> IsNonZero<TObject>(this IValitRule<TObject, uint> rule) where TObject : class
-            => rule.Satisfies(p => p != 0u);
+            => rule.Satisfies(p => p != 0u).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, uint?> IsNonZero<TObject>(this IValitRule<TObject, uint?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0u);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0u).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, uint?> Required<TObject>(this IValitRule<TObject, uint?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRuleUInt64Extensions.cs
+++ b/src/Valit/ValitRuleUInt64Extensions.cs
@@ -1,83 +1,85 @@
+using Valit.Errors;
+
 namespace Valit
 {
     public static class ValitRuleUInt64Extensions
     {
         public static IValitRule<TObject, ulong> IsGreaterThan<TObject>(this IValitRule<TObject, ulong> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p > value);
+            => rule.Satisfies(p => p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, ulong> IsGreaterThan<TObject>(this IValitRule<TObject, ulong> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p > value.Value);
+            => rule.Satisfies(p => value.HasValue && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, ulong?> IsGreaterThan<TObject>(this IValitRule<TObject, ulong?> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value > value);
+            => rule.Satisfies(p => p.HasValue && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, ulong?> IsGreaterThan<TObject>(this IValitRule<TObject, ulong?> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
 
         public static IValitRule<TObject, ulong> IsLessThan<TObject>(this IValitRule<TObject, ulong> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p < value);
+            => rule.Satisfies(p => p < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, ulong> IsLessThan<TObject>(this IValitRule<TObject, ulong> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p < value.Value);
+            => rule.Satisfies(p => value.HasValue && p < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, ulong?> IsLessThan<TObject>(this IValitRule<TObject, ulong?> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value < value);
+            => rule.Satisfies(p => p.HasValue && p.Value < value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, ulong?> IsLessThan<TObject>(this IValitRule<TObject, ulong?> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value < value.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
 
         public static IValitRule<TObject, ulong> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, ulong> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p >= value);
+            => rule.Satisfies(p => p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, ulong> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, ulong> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p >= value.Value);
+            => rule.Satisfies(p => value.HasValue && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, ulong?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, ulong?> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value >= value);
+            => rule.Satisfies(p => p.HasValue && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, ulong?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, ulong?> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, ulong> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, ulong> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p <= value);
+            => rule.Satisfies(p => p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, ulong> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, ulong> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p <= value.Value);
+            => rule.Satisfies(p => value.HasValue && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
 
         public static IValitRule<TObject, ulong?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, ulong?> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value <= value);
+            => rule.Satisfies(p => p.HasValue && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, ulong?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, ulong?> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, ulong> IsEqualTo<TObject>(this IValitRule<TObject, ulong> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p == value);
+            => rule.Satisfies(p => p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, ulong> IsEqualTo<TObject>(this IValitRule<TObject, ulong> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && p == value.Value);
+            => rule.Satisfies(p => value.HasValue && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, ulong?> IsEqualTo<TObject>(this IValitRule<TObject, ulong?> rule, ulong value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value == value);
+            => rule.Satisfies(p => p.HasValue && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, ulong?> IsEqualTo<TObject>(this IValitRule<TObject, ulong?> rule, ulong? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
 
         public static IValitRule<TObject, ulong> IsNonZero<TObject>(this IValitRule<TObject, ulong> rule) where TObject : class
-            => rule.Satisfies(p => p != 0UL);
+            => rule.Satisfies(p => p != 0UL).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, ulong?> IsNonZero<TObject>(this IValitRule<TObject, ulong?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && p.Value != 0UL);
+            => rule.Satisfies(p => p.HasValue && p.Value != 0UL).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, ulong?> Required<TObject>(this IValitRule<TObject, ulong?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue);
+            => rule.Satisfies(p => p.HasValue).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/src/Valit/ValitRules.cs
+++ b/src/Valit/ValitRules.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Valit.Exceptions;
 using Valit.MessageProvider;
 using Valit.Result;
@@ -41,7 +42,7 @@ namespace Valit
             return this;
         }
 
-        IValitRules<TObject> IValitRules<TObject>.Ensure<TProperty>(Func<TObject, TProperty> selector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc)
+        IValitRules<TObject> IValitRules<TObject>.Ensure<TProperty>(Expression<Func<TObject, TProperty>> selector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc)
         {
             selector.ThrowIfNull();
             ruleFunc.ThrowIfNull();
@@ -50,7 +51,7 @@ namespace Valit
             return this;
         }
 
-        IValitRules<TObject> IValitRules<TObject>.Ensure<TProperty>(Func<TObject, TProperty> selector, IValitator<TProperty> valitator)
+        IValitRules<TObject> IValitRules<TObject>.Ensure<TProperty>(Expression<Func<TObject, TProperty>> selector, IValitator<TProperty> valitator)
         {
             selector.ThrowIfNull();
             valitator.ThrowIfNull();
@@ -60,7 +61,7 @@ namespace Valit
             return this;
         }
 
-        IValitRules<TObject> IValitRules<TObject>.EnsureFor<TProperty>(Func<TObject, IEnumerable<TProperty>> selector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc)
+        IValitRules<TObject> IValitRules<TObject>.EnsureFor<TProperty>(Expression<Func<TObject, IEnumerable<TProperty>>> selector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc)
         {
             selector.ThrowIfNull();
             ruleFunc.ThrowIfNull();
@@ -70,7 +71,7 @@ namespace Valit
             return this;
         }
 
-        IValitRules<TObject> IValitRules<TObject>.EnsureFor<TProperty>(Func<TObject, IEnumerable<TProperty>> selector, IValitator<TProperty> valitator)
+        IValitRules<TObject> IValitRules<TObject>.EnsureFor<TProperty>(Expression<Func<TObject, IEnumerable<TProperty>>> selector, IValitator<TProperty> valitator)
         {
             selector.ThrowIfNull();
             valitator.ThrowIfNull();
@@ -119,7 +120,7 @@ namespace Valit
         private IValitResult Validate(IEnumerable<IValitRule<TObject>> rules)
             => rules.ValidateRules(_strategy, _object);
 
-        private void AddEnsureRules<TProperty>(Func<TObject,TProperty> propertySelector, Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> ruleFunc)
+        private void AddEnsureRules<TProperty>(Expression<Func<TObject,TProperty>> propertySelector, Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> ruleFunc)
         {
             var lastEnsureRule = ruleFunc(new ValitRule<TObject, TProperty>(propertySelector, _messageProvider));
             var ensureRules = lastEnsureRule.GetAllEnsureRules();

--- a/tests/Valit.Tests/Property/Property_WithDefaultMessage_Tests.cs
+++ b/tests/Valit.Tests/Property/Property_WithDefaultMessage_Tests.cs
@@ -1,0 +1,53 @@
+using Shouldly;
+using Xunit;
+
+namespace Valit.Tests.Property
+{
+    public class Property_WithDefaultMessage_Tests
+    {
+        [Fact]
+        public void DefaultMessage_Is_Added_If_No_ErrorMessage_Is_Given()
+        {
+            var result = ValitRules<Model>.Create()
+                .Ensure(m => m.Value, _ => _
+                    .IsNegative())
+                .Ensure(m => m.NullValue, _ => _
+                    .Required())
+                .For(_model)
+                .Validate();
+
+            result.ErrorMessages.Length.ShouldBe(2);
+        }
+
+        [Fact]
+        public void DefaultMessage_Is_Overriten_If_ErrorMessage_Is_Given()
+        {
+            var result = ValitRules<Model>.Create()
+                .Ensure(m => m.Value, _ => _
+                    .IsNegative()
+                    .WithMessage("1"))
+                .Ensure(m => m.NullValue, _ => _
+                    .Required()
+                    .WithMessage("2"))
+                .For(_model)
+                .Validate();
+
+            result.ErrorMessages.Length.ShouldBe(2);
+            result.ErrorMessages.ShouldContain("1");
+            result.ErrorMessages.ShouldContain("2");
+        }
+
+        public Property_WithDefaultMessage_Tests()
+        {
+            _model = new Model();
+        }
+
+        private readonly Model _model;
+
+        class Model
+        {
+            public int Value => 12;
+            public object NullValue => null;
+        }
+    }
+}


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. #113 

Since default messages are required in #148 issue I decided to implement that one. There're lots o changes but basically most of them is just adding new, internal ``WithDefaultMessage`` method. To get the proper messages I changed all property selectors to expressions so I could fairly easy take the name of the property and put into message. The next step was to implement ``WithDefaultMessage`` method which do the trick - creates the message and puts it into the rule. Another change is placed inside ``ValitRuleError`` class. I added new property ``IsDefault`` which informs whether the error comes from default error message or not. This is used inside the ``Validate`` method in ``ValitRule`` when I check whether errors collection contains any non-default messages. If so, we take only non-default. Otherwise we get default. The last change was changing the implementation of ``Email`` rule since it used ``Match`` beneath which caused doubled default messages. 

However this feature have two limitations:
1. Property selector must be a ``MemberExpression``. If it's not then instead of property name we put ``string.Empty``. To explain that I'll use an example. This is what we support:

```cs

Ensure(m => m.Value)
```

It's very simple to get the "Value" name from the tree. However in some of our tests we did something like this:

```cs
Ensure(m => useNullValue? m.NullValue : m.NullableValue)
```

Now this one is a ``ConditionalExpression`` which we need to evaluate first in order to get the proper expression (proper branch in the expression tree). Of course we could do this since we have an access to the ``useNullValue``. But consider the following example:

```cs
Ensure(m => m.UseNullableValue ? m.NullableValue : m.NullValue)
```

It's another ``ConditionalExpression`` but we cannot evaluate it without the actual object which is passed later in the ``For`` method. Because of that, together with Arek, we decided that for safetyness we'll support only simple selectors as shown at the beggining. 


2. When we do ``EnsureFor`` the only name we have is the name of the collection, not each element. So in this kind of messages the name of property is for a now "p" :D I guess I could replace this with "element".


# Changes
- Changed all property selectors to ``Expression<Func<TModel, TProperty>>
- Added ``IsDefault`` flag inside ``ValitRuleError``
- Modified ``Validate`` method inside ``ValitRule``
- Added ``WithDefaultMessage`` internal method
- Added ``WithMessage`` internal method use by both ``WithMessage`` and ``WithDefaultMessage``
- Applied ``WithDefaultMessage`` on every rule