### PR TITLE
Remove IValitRulesProvider

### DIFF
--- a/src/Valit/IValitRulesProvider.cs
+++ b/src/Valit/IValitRulesProvider.cs
@@ -1,9 +1,0 @@
-using System.Collections.Generic;
-
-namespace Valit
-{
-    public interface IValitRulesProvider<TObject> where TObject : class
-    {
-        IEnumerable<IValitRule<TObject>> GetRules();
-    }
-}

--- a/src/Valit/Validators/Valitator.cs
+++ b/src/Valit/Validators/Valitator.cs
@@ -6,16 +6,9 @@ namespace Valit.Validators
     {
         private readonly IValitRulesStrategyPicker<TObject> _strategyPicker;
 
-        internal Valitator(IValitRulesProvider<TObject> valitRulesProvider)
-        {
-            var rules = valitRulesProvider.GetRules();
-            _strategyPicker = ValitRules<TObject>.Create(rules);
-        }
-
         internal Valitator(IValitRules<TObject> valitRules)
         {
-            var rules = valitRules.GetAllRules();
-            _strategyPicker = ValitRules<TObject>.Create(rules);
+            _strategyPicker = ValitRules<TObject>.Create(valitRules);
         }
 
         IValitResult IValitator<TObject>.Validate(TObject @object, IValitStrategy strategy)

--- a/src/Valit/ValitRules.cs
+++ b/src/Valit/ValitRules.cs
@@ -27,8 +27,14 @@ namespace Valit
             _messageProvider = new EmptyMessageProvider();
         }
 
-        public static IValitRulesMessageProvider<TObject> Create(IEnumerable<IValitRule<TObject>> rules = null)
-            => new ValitRules<TObject>(rules);
+        public static IValitRulesMessageProvider<TObject> Create()
+           => new ValitRules<TObject>(Enumerable.Empty<IValitRule<TObject>>());
+
+        public static IValitRulesMessageProvider<TObject> Create(IValitRules<TObject> rules)
+        {
+            rules.ThrowIfNull();
+            return new ValitRules<TObject>(rules.GetAllRules());
+        }
 
         IValitRulesStrategyPicker<TObject> IValitRulesMessageProvider<TObject>.WithMessageProvider<TKey>(IValitMessageProvider<TKey> messageProvider)
         {
@@ -120,7 +126,7 @@ namespace Valit
         private IValitResult Validate(IEnumerable<IValitRule<TObject>> rules)
             => rules.ValidateRules(_strategy, _object);
 
-        private void AddEnsureRules<TProperty>(Expression<Func<TObject,TProperty>> propertySelector, Func<IValitRule<TObject, TProperty>,IValitRule<TObject, TProperty>> ruleFunc)
+        private void AddEnsureRules<TProperty>(Expression<Func<TObject, TProperty>> propertySelector, Func<IValitRule<TObject, TProperty>, IValitRule<TObject, TProperty>> ruleFunc)
         {
             var lastEnsureRule = ruleFunc(new ValitRule<TObject, TProperty>(propertySelector, _messageProvider));
             var ensureRules = lastEnsureRule.GetAllEnsureRules();

--- a/src/Valit/ValitRulesExtensions.cs
+++ b/src/Valit/ValitRulesExtensions.cs
@@ -3,7 +3,7 @@ using Valit.Validators;
 
 namespace Valit
 {
-    public static class ValitRulesProviderExtensions
+    public static class ValitRulesExtensions
     {
         public static IValitator<TObject> CreateValitator<TObject>(this IValitRules<TObject> valitRules) where TObject : class
         {

--- a/src/Valit/ValitatorExtensions.cs
+++ b/src/Valit/ValitatorExtensions.cs
@@ -5,16 +5,10 @@ namespace Valit
 {
     public static class ValitRulesProviderExtensions
     {
-        public static IValitator<TObject> CreateValitator<TObject>(this IValitRulesProvider<TObject> valitRulesProvider) where TObject : class
-        {
-            valitRulesProvider.ThrowIfNull();
-            return new Valitator<TObject>(valitRulesProvider);
-        }
-
         public static IValitator<TObject> CreateValitator<TObject>(this IValitRules<TObject> valitRules) where TObject : class
         {
             valitRules.ThrowIfNull();
             return new Valitator<TObject>(valitRules);
-        }        
+        }
     }
 }

--- a/tests/Valit.Tests/NestedObject/Nested_Object_Collection_Validation_Tests.cs
+++ b/tests/Valit.Tests/NestedObject/Nested_Object_Collection_Validation_Tests.cs
@@ -87,7 +87,7 @@ namespace Valit.Tests.NestedObject
 
         public Nested_Object_Collection_Validation_Tests()
         {
-            _modelValitator = new NestedModelRulesProvider().CreateValitator();
+            _modelValitator = new NestedModelRulesProvider().GetRules().CreateValitator();
         }
 
         private readonly IValitator<NestedModel> _modelValitator;
@@ -122,9 +122,9 @@ namespace Valit.Tests.NestedObject
             public string StringValue { get; set; }
         }
 
-        class NestedModelRulesProvider : IValitRulesProvider<NestedModel>
+        class NestedModelRulesProvider
         {
-            public IEnumerable<IValitRule<NestedModel>> GetRules()
+            public IValitRules<NestedModel> GetRules()
                 => ValitRules<NestedModel>
                         .Create()
                         .Ensure(m => m.NumericValue, _ => _
@@ -134,8 +134,7 @@ namespace Valit.Tests.NestedObject
                             .Required()
                                 .WithMessage("Two")
                             .Email()
-                                .WithMessage("Three"))
-                        .GetAllRules();
+                                .WithMessage("Three"));
         }
     }
     #endregion

--- a/tests/Valit.Tests/NestedObject/Nested_Object_Validation_Tests.cs
+++ b/tests/Valit.Tests/NestedObject/Nested_Object_Validation_Tests.cs
@@ -68,7 +68,7 @@ namespace Valit.Tests.NestedObject
 
         public Nested_Object_Validation_Tests()
         {
-            _modelValitator = new NestedModelRulesProvider().CreateValitator();
+            _modelValitator = new NestedModelRulesProvider().GetRules().CreateValitator();
         }
 
         private readonly IValitator<NestedModel> _modelValitator;
@@ -104,9 +104,9 @@ namespace Valit.Tests.NestedObject
             public string StringValue { get; set; }
         }
 
-        class NestedModelRulesProvider : IValitRulesProvider<NestedModel>
+        class NestedModelRulesProvider
         {
-            public IEnumerable<IValitRule<NestedModel>> GetRules()
+            public IValitRules<NestedModel> GetRules()
                 => ValitRules<NestedModel>
                         .Create()
                         .Ensure(m => m.NumericValue, _ => _
@@ -116,8 +116,7 @@ namespace Valit.Tests.NestedObject
                             .Required()
                                 .WithMessage("Two")
                             .Email()
-                                .WithMessage("Three"))
-                        .GetAllRules();
+                                .WithMessage("Three"));
         }
     }
     #endregion

--- a/tests/Valit.Tests/Property/Property_Tag_Tests.cs
+++ b/tests/Valit.Tests/Property/Property_Tag_Tests.cs
@@ -152,8 +152,7 @@ namespace Valit.Tests.Property
                     .Email())
                 .Ensure(m => m.NullValue, _=>_
                     .Required()
-                    .Tag("Tag2"))
-                .GetAllRules();
+                    .Tag("Tag2"));
 
             var newRules = ValitRules<Model>
                 .Create(rules)

--- a/tests/Valit.Tests/Valitator/Valitator_MessageProvider_Tests.cs
+++ b/tests/Valit.Tests/Valitator/Valitator_MessageProvider_Tests.cs
@@ -7,20 +7,9 @@ namespace Valit.Tests.Valitator
     public class Valitator_MessageProvider_Tests
     {
         [Fact]
-        public void CreateValitator_Throws_When_Null_ValitRulesProvider_Is_Given()
-        {
-            var exception = Record.Exception(() =>
-            {
-                var valitator = ((IValitRulesProvider<Model>)null).CreateValitator();
-            });
-
-            exception.ShouldBeOfType(typeof(ValitException));
-        }
-
-        [Fact]
         public void Created_Valitator_Properly_Handles_Complete_Strategy()
         {
-            var valitator = new ModelRulesProvider().CreateValitator();
+            var valitator = new ModelRulesProvider().GetRules().CreateValitator();
             var result = valitator.Validate(_model);
 
             result.Succeeded.ShouldBeFalse();
@@ -32,7 +21,7 @@ namespace Valit.Tests.Valitator
         [Fact]
         public void Created_Valitator_Properly_Handles_FailFast_Strategy()
         {
-            var valitator = new ModelRulesProvider().CreateValitator();
+            var valitator = new ModelRulesProvider().GetRules().CreateValitator();
             var result = valitator.Validate(_model, new FailFastValitStrategy());
 
             result.Succeeded.ShouldBeFalse();
@@ -50,9 +39,9 @@ namespace Valit.Tests.Valitator
             public string StringValue { get; set; }
         }
 
-        class ModelRulesProvider : IValitRulesProvider<Model>
+        class ModelRulesProvider
         {
-            public IEnumerable<IValitRule<Model>> GetRules()
+            public IValitRules<Model> GetRules()
                 => ValitRules<Model>
                         .Create()
                         .Ensure(m => m.NumericValue, _ => _
@@ -62,8 +51,7 @@ namespace Valit.Tests.Valitator
                             .Required()
                                 .WithMessage("Two")
                             .Email()
-                                .WithMessage("Three"))
-                        .GetAllRules();
+                                .WithMessage("Three"));
         }
 
         private readonly Model _model;


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. #154 

# Changes
- Removed `IValitRulesProvider`
- Removed `CreateValitator` extension for `IValitRulesProvider`
- Removed `IValitRulesProvider` ctor for `Validator`
- Changed `Create` in `ValitRules` to accept `IValitRules<TObject>` instead of `IEnumerable<IValitRule<TObject>>`
- Changed tests
  