### PR TITLE
Modifies ValitRuleStringExtensions to consider a zero length string a valid string.

### DIFF
--- a/src/Valit/ValitRuleStringExtensions.cs
+++ b/src/Valit/ValitRuleStringExtensions.cs
@@ -8,21 +8,21 @@ namespace Valit
     {
         private static string _emailRegularExpression => @"\A(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\Z";
         public static IValitRule<TObject, string> IsEqualTo<TObject>(this IValitRule<TObject, string> rule, string value) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && !String.IsNullOrEmpty(value) && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+            => rule.Satisfies(p => p != null && value != null && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, string> MinLength<TObject>(this IValitRule<TObject, string> rule, int length) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && p.Length >= length).WithDefaultMessage(ErrorMessages.MinLength, length);
+            => rule.Satisfies(p => p != null && p.Length >= length).WithDefaultMessage(ErrorMessages.MinLength, length);
 
         public static IValitRule<TObject, string> MaxLength<TObject>(this IValitRule<TObject, string> rule, int length) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && p.Length <= length).WithDefaultMessage(ErrorMessages.MaxLength, length);
+            => rule.Satisfies(p => p != null && p.Length <= length).WithDefaultMessage(ErrorMessages.MaxLength, length);
 
         public static IValitRule<TObject, string> Matches<TObject>(this IValitRule<TObject, string> rule, string regularExpression) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && !String.IsNullOrEmpty(regularExpression) && Regex.IsMatch(p, regularExpression)).WithDefaultMessage(ErrorMessages.Matches, regularExpression);
+            => rule.Satisfies(p => p != null && !String.IsNullOrEmpty(regularExpression) && Regex.IsMatch(p, regularExpression)).WithDefaultMessage(ErrorMessages.Matches, regularExpression);
 
         public static IValitRule<TObject, string> Email<TObject>(this IValitRule<TObject, string> rule) where TObject : class
-            => rule.Satisfies(p => !String.IsNullOrEmpty(p) && !String.IsNullOrEmpty(_emailRegularExpression) && Regex.IsMatch(p, _emailRegularExpression)).WithDefaultMessage(ErrorMessages.Email);
+            => rule.Satisfies(p => p != null && !String.IsNullOrEmpty(_emailRegularExpression) && Regex.IsMatch(p, _emailRegularExpression)).WithDefaultMessage(ErrorMessages.Email);
 
         public static IValitRule<TObject, string> Required<TObject>(this IValitRule<TObject, string> rule) where TObject : class
-            => rule.Satisfies(p => !string.IsNullOrEmpty(p)).WithDefaultMessage(ErrorMessages.Required);
+            => rule.Satisfies(p => p != null).WithDefaultMessage(ErrorMessages.Required);
     }
 }

--- a/tests/Valit.Tests/Strategies/Complete.cs
+++ b/tests/Valit.Tests/Strategies/Complete.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.Strategies
                 .Validate();
 
             result.Succeeded.ShouldBe(false);
-            result.ErrorMessages.Count().ShouldBe(6);
+            result.ErrorMessages.Count().ShouldBe(5);
             result.ErrorMessages.ShouldContain(M1);
             result.ErrorMessages.ShouldContain(M3);
             result.ErrorMessages.ShouldContain(M4);

--- a/tests/Valit.Tests/Strategies/FailFast.cs
+++ b/tests/Valit.Tests/Strategies/FailFast.cs
@@ -68,7 +68,7 @@ namespace Valit.Tests.Strategies
 
             result.Succeeded.ShouldBe(false);
             result.ErrorMessages.Count().ShouldBe(1);
-            result.ErrorMessages.ShouldContain(M2);
+            result.ErrorMessages.ShouldContain(M3);
         }
 
 #region ARRANGE

--- a/tests/Valit.Tests/String/String_IsEqualTo_Tests.cs
+++ b/tests/Valit.Tests/String/String_IsEqualTo_Tests.cs
@@ -36,7 +36,7 @@ namespace Valit.Tests.String
         [Theory]
         [InlineData("text", false)]
         [InlineData("other", false)]
-        [InlineData("", false)]
+        [InlineData("", true)]
         [InlineData(null, false)]
         public void String_IsEqualTo_Returns_Proper_Result_For_Left_Empty_Value(string value, bool expected)
         {

--- a/tests/Valit.Tests/String/String_MaxLength_Tests.cs
+++ b/tests/Valit.Tests/String/String_MaxLength_Tests.cs
@@ -33,9 +33,9 @@ namespace Valit.Tests.String
         }
 
         [Theory]
-        [InlineData(0, false)]
-        [InlineData(4, false)]
-        [InlineData(8, false)]
+        [InlineData(0, true)]
+        [InlineData(4, true)]
+        [InlineData(8, true)]
         public void String_MaxLength_Returns_Proper_Result_For_Left_Empty_Value(int value, bool expected)
         {
             IValitResult result = ValitRules<Model>

--- a/tests/Valit.Tests/String/String_MinLength_Tests.cs
+++ b/tests/Valit.Tests/String/String_MinLength_Tests.cs
@@ -33,7 +33,7 @@ namespace Valit.Tests.String
         }
 
         [Theory]
-        [InlineData(0, false)]
+        [InlineData(0, true)]
         [InlineData(4, false)]
         [InlineData(8, false)]
         public void String_MinLength_Returns_Proper_Result_For_Left_Empty_Value(int value, bool expected)

--- a/tests/Valit.Tests/String/String_Required_Tests.cs
+++ b/tests/Valit.Tests/String/String_Required_Tests.cs
@@ -33,7 +33,7 @@ namespace Valit.Tests.String
         }
 
         [Fact]
-        public void String_Required_Fails_For_Empty_Value()
+        public void String_Required_Succeeds_For_Empty_Value()
         {
             IValitResult result = ValitRules<Model>
                 .Create()
@@ -42,7 +42,7 @@ namespace Valit.Tests.String
                 .For(_model)
                 .Validate();
 
-            result.Succeeded.ShouldBeFalse();
+            result.Succeeded.ShouldBeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. [116](https://github.com/valit-stack/Valit/issues/166) 

# Changes
- Changed ValitRuleStringExtensions precondition checks from String.IsNullOrEmpty to only check null.
    - Causes MinValue(0) against "" to pass validation (previously would fail validation).
    - Causes MaxValue(m), where m > 0 to pass validation (previously would fail validation).
    - In general, allows the empty string to be a valid value for a string.  