### PR TITLE
32

### DIFF
--- a/src/Valit/Extensions/DoubleExtensions.cs
+++ b/src/Valit/Extensions/DoubleExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Valit.Extensions
+{
+    public static class DoubleExtensions
+    {
+        public static bool IsEqualTo(this double a, double b, double epsilon)
+        {
+            if (epsilon == .0d)
+                return a == b;
+            else
+                return a.IsNearlyEqual(b, epsilon);
+        }
+
+        public static bool IsNotEqual(this double a, double b, double epsilon)  => !IsEqualTo(a, b, epsilon);
+
+        /// <summary>
+        /// receipes taken from: https://floating-point-gui.de/errors/comparison/
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="epsilon"></param>
+        /// <returns></returns>
+        public static bool IsNearlyEqual(this double a, double b, double epsilon)
+        {
+            double absA = Math.Abs(a);
+            double absB = Math.Abs(b);
+            double diff = Math.Abs(a - b);
+
+            if (a == b)
+            { // shortcut, handles infinities
+                return true;
+            }
+            else if (a == 0 || b == 0 || diff < Double.MinValue)
+            {
+                // a or b is zero or both are extremely close to it
+                // relative error is less meaningful here
+                return diff < (epsilon * Double.MinValue);
+            }
+            else
+            { // use relative error
+                return diff / Math.Min((absA + absB), Double.MaxValue) < epsilon;
+            }
+        }
+
+        public static bool IsGreaterThan(this double a, double b, double epsilon) => IsNotEqual(a, b, epsilon) && a > b;
+
+        public static bool IsGreaterOrEqualThan(this double a, double b, double epsilon) => IsEqualTo(a, b, epsilon) || a > b;
+
+        public static bool IsLessThan(this double a, double b, double epsilon) => IsNotEqual(a, b, epsilon) && a < b;
+
+        public static bool IsLessOrEqualThan(this double a, double b, double epsilon) => IsEqualTo(a, b, epsilon) || a < b;
+    }
+}

--- a/src/Valit/Extensions/DoubleExtensions.cs
+++ b/src/Valit/Extensions/DoubleExtensions.cs
@@ -4,7 +4,7 @@ namespace Valit.Extensions
 {
     public static class DoubleExtensions
     {
-        public static bool IsEqualTo(this double a, double b, double epsilon)
+        public static bool IsEqual(this double a, double b, double epsilon)
         {
             if (epsilon == .0d)
                 return a == b;
@@ -12,7 +12,15 @@ namespace Valit.Extensions
                 return a.IsNearlyEqual(b, epsilon);
         }
 
-        public static bool IsNotEqual(this double a, double b, double epsilon)  => !IsEqualTo(a, b, epsilon);
+        public static bool IsNotEqual(this double a, double b, double epsilon)  => !IsEqual(a, b, epsilon);
+
+        public static bool IsGreaterThan(this double a, double b, double epsilon) => IsNotEqual(a, b, epsilon) && a > b;
+
+        public static bool IsGreaterOrEqualThan(this double a, double b, double epsilon) => IsEqual(a, b, epsilon) || a > b;
+
+        public static bool IsLessThan(this double a, double b, double epsilon) => IsNotEqual(a, b, epsilon) && a < b;
+
+        public static bool IsLessOrEqualThan(this double a, double b, double epsilon) => IsEqual(a, b, epsilon) || a < b;
 
         /// <summary>
         /// receipes taken from: https://floating-point-gui.de/errors/comparison/
@@ -48,13 +56,5 @@ namespace Valit.Extensions
                 return diff / Math.Min((absA + absB), Double.MaxValue) < epsilon;
             }
         }
-
-        public static bool IsGreaterThan(this double a, double b, double epsilon) => IsNotEqual(a, b, epsilon) && a > b;
-
-        public static bool IsGreaterOrEqualThan(this double a, double b, double epsilon) => IsEqualTo(a, b, epsilon) || a > b;
-
-        public static bool IsLessThan(this double a, double b, double epsilon) => IsNotEqual(a, b, epsilon) && a < b;
-
-        public static bool IsLessOrEqualThan(this double a, double b, double epsilon) => IsEqualTo(a, b, epsilon) || a < b;
     }
 }

--- a/src/Valit/Extensions/DoubleExtensions.cs
+++ b/src/Valit/Extensions/DoubleExtensions.cs
@@ -21,8 +21,14 @@ namespace Valit.Extensions
         /// <param name="b"></param>
         /// <param name="epsilon"></param>
         /// <returns></returns>
-        public static bool IsNearlyEqual(this double a, double b, double epsilon)
+        private static bool IsNearlyEqual(this double a, double b, double epsilon)
         {
+            if (Double.IsNaN(a) || Double.IsNaN(b))
+                return false;
+
+            if (Double.IsNaN(epsilon))
+                epsilon = Double.Epsilon;
+
             double absA = Math.Abs(a);
             double absB = Math.Abs(b);
             double diff = Math.Abs(a - b);

--- a/src/Valit/Extensions/DoubleExtensions.cs
+++ b/src/Valit/Extensions/DoubleExtensions.cs
@@ -4,6 +4,9 @@ namespace Valit.Extensions
 {
     public static class DoubleExtensions
     {
+        static readonly double MIN_NORMAL = BitConverter.ToDouble(new byte[] { 00, 00, 00, 00, 00, 00, 0x10, 00 }, 0);
+        static readonly double MAX_VALUE = Double.MaxValue;
+
         public static bool IsEqual(this double a, double b, double epsilon)
         {
             if (epsilon == .0d)
@@ -45,16 +48,21 @@ namespace Valit.Extensions
             { // shortcut, handles infinities
                 return true;
             }
-            else if (a == 0 || b == 0 || diff < Double.MinValue)
+            else if (a == 0 || b == 0 || diff < MIN_NORMAL)
             {
                 // a or b is zero or both are extremely close to it
                 // relative error is less meaningful here
-                return diff < (epsilon * Double.MinValue);
+                return diff < (epsilon * MIN_NORMAL);
             }
             else
             { // use relative error
-                return diff / Math.Min((absA + absB), Double.MaxValue) < epsilon;
+                return diff / Math.Min((absA + absB), MAX_VALUE) < epsilon;
             }
+        }
+
+        private static bool HasValue(this double? a)
+        {
+            return a.HasValue && !Double.IsNaN(a.Value);
         }
     }
 }

--- a/src/Valit/Extensions/DoubleExtensions.cs
+++ b/src/Valit/Extensions/DoubleExtensions.cs
@@ -15,7 +15,7 @@ namespace Valit.Extensions
                 return a.IsNearlyEqual(b, epsilon);
         }
 
-        public static bool IsNotEqual(this double a, double b, double epsilon)  => !IsEqual(a, b, epsilon);
+        public static bool IsNotEqual(this double a, double b, double epsilon) => !IsEqual(a, b, epsilon);
 
         public static bool IsGreaterThan(this double a, double b, double epsilon) => IsNotEqual(a, b, epsilon) && a > b;
 
@@ -58,11 +58,6 @@ namespace Valit.Extensions
             { // use relative error
                 return diff / Math.Min((absA + absB), MAX_VALUE) < epsilon;
             }
-        }
-
-        private static bool HasValue(this double? a)
-        {
-            return a.HasValue && !Double.IsNaN(a.Value);
         }
     }
 }

--- a/src/Valit/Extensions/FloatExtensions.cs
+++ b/src/Valit/Extensions/FloatExtensions.cs
@@ -8,7 +8,7 @@ namespace Valit.Extensions
 
         public static bool IsEqual(this float a, float b, float epsilon)
         {
-            if (epsilon == .0d)
+            if (epsilon == .0f)
                 return a == b;
             else
                 return a.IsNearlyEqual(b, epsilon);

--- a/src/Valit/Extensions/FloatExtensions.cs
+++ b/src/Valit/Extensions/FloatExtensions.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Valit.Extensions
+{
+    public static class FloatExtensions
+    {
+        private static readonly float MIN_NORMAL = BitConverter.ToSingle(new byte[] { 0, 0, 0x80, 0 }, 0);
+
+        public static bool IsEqual(this float a, float b, float epsilon)
+        {
+            if (epsilon == .0d)
+                return a == b;
+            else
+                return a.IsNearlyEqual(b, epsilon);
+        }
+
+        public static bool IsNotEqual(this float a, float b, float epsilon) => !IsEqual(a, b, epsilon);
+
+        public static bool IsGreaterThan(this float a, float b, float epsilon) => IsNotEqual(a, b, epsilon) && a > b;
+
+        public static bool IsGreaterOrEqualThan(this float a, float b, float epsilon) => IsEqual(a, b, epsilon) || a > b;
+
+        public static bool IsLessThan(this float a, float b, float epsilon) => IsNotEqual(a, b, epsilon) && a < b;
+
+        public static bool IsLessOrEqualThan(this float a, float b, float epsilon) => IsEqual(a, b, epsilon) || a < b;
+
+        private static bool IsNearlyEqual(this float a, float b, float epsilon)
+        {
+            if (float.IsNaN(a) || float.IsNaN(b))
+                return false;
+
+            if (float.IsNaN(epsilon))
+                epsilon = float.Epsilon;
+
+            float absA = Math.Abs(a);
+            float absB = Math.Abs(b);
+            float diff = Math.Abs(a - b);
+
+            if (a == b)
+            { // shortcut, handles infinities
+                return true;
+            }
+            else if (a == 0 || b == 0 || diff < MIN_NORMAL)
+            {
+                // a or b is zero or both are extremely close to it
+                // relative error is less meaningful here
+                return diff < (epsilon * MIN_NORMAL);
+            }
+            else
+            { // use relative error
+                return diff / Math.Min((absA + absB), float.MaxValue) < epsilon;
+            }
+        }
+    }
+}

--- a/src/Valit/ValitRuleDoubleExtensions.cs
+++ b/src/Valit/ValitRuleDoubleExtensions.cs
@@ -18,71 +18,71 @@ namespace Valit
         public static IValitRule<TObject, double?> IsGreaterThan<TObject>(this IValitRule<TObject, double?> rule, double? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value.IsGreaterThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, double> IsLessThan<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
+        public static IValitRule<TObject, double> IsLessThan<TObject>(this IValitRule<TObject, double> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p.IsLessThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, double> IsLessThan<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && value.Value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
+        public static IValitRule<TObject, double> IsLessThan<TObject>(this IValitRule<TObject, double> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p.IsLessThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, double?> IsLessThan<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
+        public static IValitRule<TObject, double?> IsLessThan<TObject>(this IValitRule<TObject, double?> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value.IsLessThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, double?> IsLessThan<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && value.Value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
+        public static IValitRule<TObject, double?> IsLessThan<TObject>(this IValitRule<TObject, double?> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value.IsLessThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, double> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
+        public static IValitRule<TObject, double> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p.IsGreaterOrEqualThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, double> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
+        public static IValitRule<TObject, double> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) &&  p.IsGreaterOrEqualThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, double?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
+        public static IValitRule<TObject, double?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value.IsGreaterOrEqualThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, double?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
+        public static IValitRule<TObject, double?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value.IsGreaterOrEqualThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, double> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
+        public static IValitRule<TObject, double> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p.IsLessOrEqualThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, double> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
+        public static IValitRule<TObject, double> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p.IsLessOrEqualThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, double?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
+        public static IValitRule<TObject, double?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value.IsLessOrEqualThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, double?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
+        public static IValitRule<TObject, double?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value.IsLessOrEqualThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, double> IsEqualTo<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+        public static IValitRule<TObject, double> IsEqualTo<TObject>(this IValitRule<TObject, double> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p.IsEqual(value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, double> IsEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+        public static IValitRule<TObject, double> IsEqualTo<TObject>(this IValitRule<TObject, double> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p.IsEqual(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, double?> IsEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+        public static IValitRule<TObject, double?> IsEqualTo<TObject>(this IValitRule<TObject, double?> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value.IsEqual(value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, double?> IsEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+        public static IValitRule<TObject, double?> IsEqualTo<TObject>(this IValitRule<TObject, double?> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value.IsEqual(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, double> IsPositive<TObject>(this IValitRule<TObject, double> rule) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && p > 0d).WithDefaultMessage(ErrorMessages.IsPositive);
+        public static IValitRule<TObject, double> IsPositive<TObject>(this IValitRule<TObject, double> rule, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => !Double.IsNaN(p) && p.IsGreaterThan(0d, epsilon)).WithDefaultMessage(ErrorMessages.IsPositive);
 
-        public static IValitRule<TObject, double?> IsPositive<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value > 0d).WithDefaultMessage(ErrorMessages.IsPositive);
+        public static IValitRule<TObject, double?> IsPositive<TObject>(this IValitRule<TObject, double?> rule, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value.IsGreaterThan(0d, epsilon)).WithDefaultMessage(ErrorMessages.IsPositive);
 
-        public static IValitRule<TObject, double> IsNegative<TObject>(this IValitRule<TObject, double> rule) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && p < 0d).WithDefaultMessage(ErrorMessages.IsNegative);
+        public static IValitRule<TObject, double> IsNegative<TObject>(this IValitRule<TObject, double> rule, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => !Double.IsNaN(p) && p.IsLessThan(0d, epsilon)).WithDefaultMessage(ErrorMessages.IsNegative);
 
-        public static IValitRule<TObject, double?> IsNegative<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value < 0d).WithDefaultMessage(ErrorMessages.IsNegative);
+        public static IValitRule<TObject, double?> IsNegative<TObject>(this IValitRule<TObject, double?> rule, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value.IsLessThan(0d, epsilon)).WithDefaultMessage(ErrorMessages.IsNegative);
 
-        public static IValitRule<TObject, double> IsNonZero<TObject>(this IValitRule<TObject, double> rule) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && p != 0d).WithDefaultMessage(ErrorMessages.IsNonZero);
+        public static IValitRule<TObject, double> IsNonZero<TObject>(this IValitRule<TObject, double> rule, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => !Double.IsNaN(p) && p.IsNotEqual(0d, epsilon)).WithDefaultMessage(ErrorMessages.IsNonZero);
 
-        public static IValitRule<TObject, double?> IsNonZero<TObject>(this IValitRule<TObject, double?> rule) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value != 0d).WithDefaultMessage(ErrorMessages.IsNonZero);
+        public static IValitRule<TObject, double?> IsNonZero<TObject>(this IValitRule<TObject, double?> rule, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && p.Value.IsNotEqual(0d, epsilon)).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, double> IsNumber<TObject>(this IValitRule<TObject, double> rule) where TObject : class
             => rule.Satisfies(p => !Double.IsNaN(p)).WithDefaultMessage(ErrorMessages.IsNumber);

--- a/src/Valit/ValitRuleDoubleExtensions.cs
+++ b/src/Valit/ValitRuleDoubleExtensions.cs
@@ -1,21 +1,22 @@
 using System;
 using Valit.Errors;
+using Valit.Extensions;
 
 namespace Valit
 {
     public static class ValitRuleDoubleExtensions
     {
-        public static IValitRule<TObject, double> IsGreaterThan<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
-            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
+        public static IValitRule<TObject, double> IsGreaterThan<TObject>(this IValitRule<TObject, double> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && p.IsGreaterThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, double> IsGreaterThan<TObject>(this IValitRule<TObject, double> rule, double? value) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
+        public static IValitRule<TObject, double> IsGreaterThan<TObject>(this IValitRule<TObject, double> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => value.HasValue && !Double.IsNaN(p) && !Double.IsNaN(value.Value) && p.IsGreaterThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, double?> IsGreaterThan<TObject>(this IValitRule<TObject, double?> rule, double value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
+        public static IValitRule<TObject, double?> IsGreaterThan<TObject>(this IValitRule<TObject, double?> rule, double value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value) && p.Value.IsGreaterThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, double?> IsGreaterThan<TObject>(this IValitRule<TObject, double?> rule, double? value) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
+        public static IValitRule<TObject, double?> IsGreaterThan<TObject>(this IValitRule<TObject, double?> rule, double? value, double epsilon = .0d) where TObject : class
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Double.IsNaN(p.Value) && !Double.IsNaN(value.Value) && p.Value.IsGreaterThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, double> IsLessThan<TObject>(this IValitRule<TObject, double> rule, double value) where TObject : class
             => rule.Satisfies(p => !Double.IsNaN(p) && !Double.IsNaN(value) && value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);

--- a/src/Valit/ValitRuleFloatExtensions.cs
+++ b/src/Valit/ValitRuleFloatExtensions.cs
@@ -67,22 +67,22 @@ namespace Valit
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value.IsEqual(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float> IsPositive<TObject>(this IValitRule<TObject, float> rule, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && p > 0f).WithDefaultMessage(ErrorMessages.IsPositive);
+            => rule.Satisfies(p => !Single.IsNaN(p) && p.IsGreaterThan(0f, epsilon)).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, float?> IsPositive<TObject>(this IValitRule<TObject, float?> rule, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value > 0f).WithDefaultMessage(ErrorMessages.IsPositive);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value.IsGreaterThan(0f, epsilon)).WithDefaultMessage(ErrorMessages.IsPositive);
 
         public static IValitRule<TObject, float> IsNegative<TObject>(this IValitRule<TObject, float> rule, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && p < 0f).WithDefaultMessage(ErrorMessages.IsNegative);
+            => rule.Satisfies(p => !Single.IsNaN(p) && p.IsLessThan(0f, epsilon)).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, float?> IsNegative<TObject>(this IValitRule<TObject, float?> rule, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value < 0f).WithDefaultMessage(ErrorMessages.IsNegative);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value.IsLessThan(0f, epsilon)).WithDefaultMessage(ErrorMessages.IsNegative);
 
         public static IValitRule<TObject, float> IsNonZero<TObject>(this IValitRule<TObject, float> rule, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && p != 0f).WithDefaultMessage(ErrorMessages.IsNonZero);
+            => rule.Satisfies(p => !Single.IsNaN(p) && p.IsNotEqual(0f, epsilon)).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, float?> IsNonZero<TObject>(this IValitRule<TObject, float?> rule, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value != 0f).WithDefaultMessage(ErrorMessages.IsNonZero);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value.IsNotEqual(0f, epsilon)).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, float> IsNumber<TObject>(this IValitRule<TObject, float> rule) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p)).WithDefaultMessage(ErrorMessages.IsNumber);

--- a/src/Valit/ValitRuleFloatExtensions.cs
+++ b/src/Valit/ValitRuleFloatExtensions.cs
@@ -5,82 +5,82 @@ namespace Valit
 {
     public static class ValitRuleFloatExtensions
     {
-        public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
+        public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
+        public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
+        public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && value.Value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
+        public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && value.Value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
+        public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
+        public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
+        public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
+        public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float value) where TObject : class
+        public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value) where TObject : class
+        public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value) where TObject : class
+        public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, float> IsPositive<TObject>(this IValitRule<TObject, float> rule) where TObject : class
+        public static IValitRule<TObject, float> IsPositive<TObject>(this IValitRule<TObject, float> rule, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && p > 0f).WithDefaultMessage(ErrorMessages.IsPositive);
 
-        public static IValitRule<TObject, float?> IsPositive<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
+        public static IValitRule<TObject, float?> IsPositive<TObject>(this IValitRule<TObject, float?> rule, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value > 0f).WithDefaultMessage(ErrorMessages.IsPositive);
 
-        public static IValitRule<TObject, float> IsNegative<TObject>(this IValitRule<TObject, float> rule) where TObject : class
+        public static IValitRule<TObject, float> IsNegative<TObject>(this IValitRule<TObject, float> rule, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && p < 0f).WithDefaultMessage(ErrorMessages.IsNegative);
 
-        public static IValitRule<TObject, float?> IsNegative<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
+        public static IValitRule<TObject, float?> IsNegative<TObject>(this IValitRule<TObject, float?> rule, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value < 0f).WithDefaultMessage(ErrorMessages.IsNegative);
 
-        public static IValitRule<TObject, float> IsNonZero<TObject>(this IValitRule<TObject, float> rule) where TObject : class
+        public static IValitRule<TObject, float> IsNonZero<TObject>(this IValitRule<TObject, float> rule, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && p != 0f).WithDefaultMessage(ErrorMessages.IsNonZero);
 
-        public static IValitRule<TObject, float?> IsNonZero<TObject>(this IValitRule<TObject, float?> rule) where TObject : class
+        public static IValitRule<TObject, float?> IsNonZero<TObject>(this IValitRule<TObject, float?> rule, double epsilon = .0d) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value != 0f).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, float> IsNumber<TObject>(this IValitRule<TObject, float> rule) where TObject : class

--- a/src/Valit/ValitRuleFloatExtensions.cs
+++ b/src/Valit/ValitRuleFloatExtensions.cs
@@ -1,69 +1,70 @@
 using System;
 using Valit.Errors;
+using Valit.Extensions;
 
 namespace Valit
 {
     public static class ValitRuleFloatExtensions
     {
         public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p.IsGreaterThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p.IsGreaterThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value.IsGreaterThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value.IsGreaterThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
         public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p.IsLessThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && value.Value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p.IsLessThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value.IsLessThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && value.Value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value.IsLessThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
         public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p.IsGreaterOrEqualThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p.IsGreaterOrEqualThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value.IsGreaterOrEqualThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value.IsGreaterOrEqualThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
         public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p.IsLessOrEqualThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p.IsLessOrEqualThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value.IsLessOrEqualThan(value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value.IsLessOrEqualThan(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
         public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+            => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p.IsEqual(value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+            => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p.IsEqual(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+            => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value.IsEqual(value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
-            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
+            => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value.IsEqual(value.Value, epsilon)).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
         public static IValitRule<TObject, float> IsPositive<TObject>(this IValitRule<TObject, float> rule, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && p > 0f).WithDefaultMessage(ErrorMessages.IsPositive);

--- a/src/Valit/ValitRuleFloatExtensions.cs
+++ b/src/Valit/ValitRuleFloatExtensions.cs
@@ -5,82 +5,82 @@ namespace Valit
 {
     public static class ValitRuleFloatExtensions
     {
-        public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsGreaterThan<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value > value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsGreaterThan<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value > value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThan, value);
 
-        public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsLessThan<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && value.Value > p).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsLessThan<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && value.Value > p.Value).WithDefaultMessage(ErrorMessages.IsLessThan, value);
 
-        public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value >= value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsGreaterThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value >= value.Value).WithDefaultMessage(ErrorMessages.IsGreaterThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value <= value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsLessThanOrEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value <= value.Value).WithDefaultMessage(ErrorMessages.IsLessThanOrEqualTo, value);
 
-        public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && !Single.IsNaN(value) && p == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsEqualTo<TObject>(this IValitRule<TObject, float> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => value.HasValue && !Single.IsNaN(p) && !Single.IsNaN(value.Value) && p == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value) && p.Value == value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsEqualTo<TObject>(this IValitRule<TObject, float?> rule, float? value, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && value.HasValue && !Single.IsNaN(p.Value) && !Single.IsNaN(value.Value) && p.Value == value.Value).WithDefaultMessage(ErrorMessages.IsEqualTo, value);
 
-        public static IValitRule<TObject, float> IsPositive<TObject>(this IValitRule<TObject, float> rule, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsPositive<TObject>(this IValitRule<TObject, float> rule, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && p > 0f).WithDefaultMessage(ErrorMessages.IsPositive);
 
-        public static IValitRule<TObject, float?> IsPositive<TObject>(this IValitRule<TObject, float?> rule, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsPositive<TObject>(this IValitRule<TObject, float?> rule, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value > 0f).WithDefaultMessage(ErrorMessages.IsPositive);
 
-        public static IValitRule<TObject, float> IsNegative<TObject>(this IValitRule<TObject, float> rule, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsNegative<TObject>(this IValitRule<TObject, float> rule, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && p < 0f).WithDefaultMessage(ErrorMessages.IsNegative);
 
-        public static IValitRule<TObject, float?> IsNegative<TObject>(this IValitRule<TObject, float?> rule, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsNegative<TObject>(this IValitRule<TObject, float?> rule, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value < 0f).WithDefaultMessage(ErrorMessages.IsNegative);
 
-        public static IValitRule<TObject, float> IsNonZero<TObject>(this IValitRule<TObject, float> rule, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float> IsNonZero<TObject>(this IValitRule<TObject, float> rule, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => !Single.IsNaN(p) && p != 0f).WithDefaultMessage(ErrorMessages.IsNonZero);
 
-        public static IValitRule<TObject, float?> IsNonZero<TObject>(this IValitRule<TObject, float?> rule, double epsilon = .0d) where TObject : class
+        public static IValitRule<TObject, float?> IsNonZero<TObject>(this IValitRule<TObject, float?> rule, float epsilon = .0f) where TObject : class
             => rule.Satisfies(p => p.HasValue && !Single.IsNaN(p.Value) && p.Value != 0f).WithDefaultMessage(ErrorMessages.IsNonZero);
 
         public static IValitRule<TObject, float> IsNumber<TObject>(this IValitRule<TObject, float> rule) where TObject : class

--- a/tests/Valit.Tests/Double/Double_IsEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsEqualTo_Tests.cs
@@ -187,6 +187,23 @@ namespace Valit.Tests.Double
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999d, 0.000001d, false)]
+        [InlineData(9.999d, 0.01d, true)]
+        [InlineData(10d, double.Epsilon, true)]
+        [InlineData(10.0001d, 0.01d, true)]
+        [InlineData(10.0001d, 0.000001d, false)]
+        public void Double_IsEqualTo_Returns_Proper_Results_For_GivenEpsilon_Value(double value, double epsilon, bool expected)
+        {
+            IValitResult results = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsEqualTo(value, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            results.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Double_IsEqualTo_Tests()
         {
@@ -198,6 +215,7 @@ namespace Valit.Tests.Double
         class Model
         {
             public double Value => 10;
+            public double Epsilon => double.Epsilon;
             public double NaN => double.NaN;
             public double? NullableValue => 10;
             public double? NullValue => null;

--- a/tests/Valit.Tests/Double/Double_IsEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsEqualTo_Tests.cs
@@ -193,7 +193,7 @@ namespace Valit.Tests.Double
         [InlineData(10d, double.Epsilon, true)]
         [InlineData(10.0001d, 0.01d, true)]
         [InlineData(10.0001d, 0.000001d, false)]
-        public void Double_IsEqualTo_Returns_Proper_Results_For_GivenEpsilon_Value(double value, double epsilon, bool expected)
+        public void Double_IsEqualTo_Returns_Proper_Results_For_Given_Epsilon_Value(double value, double epsilon, bool expected)
         {
             IValitResult results = ValitRules<Model>
                                     .Create()

--- a/tests/Valit.Tests/Double/Double_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsGreaterThanOrEqualTo_Tests.cs
@@ -192,7 +192,7 @@ namespace Valit.Tests.Double
         [InlineData(10d, double.Epsilon, true)]
         [InlineData(10.0001d, 0.01d, true)]
         [InlineData(10.0001d, 0.000001d, false)]
-        public void Double_IsGreaterThanOrEqual_Returns_Proper_Results_For_GivenEpsilon_Value(double value, double epsilon, bool expected)
+        public void Double_IsGreaterThanOrEqual_Returns_Proper_Results_For_Given_Epsilon_Value(double value, double epsilon, bool expected)
         {
             IValitResult results = ValitRules<Model>
                                     .Create()

--- a/tests/Valit.Tests/Double/Double_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsGreaterThanOrEqualTo_Tests.cs
@@ -186,6 +186,24 @@ namespace Valit.Tests.Double
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999d, 0.000001d, true)]
+        [InlineData(9.999d, 0.01d, true)]
+        [InlineData(10d, double.Epsilon, true)]
+        [InlineData(10.0001d, 0.01d, true)]
+        [InlineData(10.0001d, 0.000001d, false)]
+        public void Double_IsGreaterThanOrEqual_Returns_Proper_Results_For_GivenEpsilon_Value(double value, double epsilon, bool expected)
+        {
+            IValitResult results = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsGreaterThanOrEqualTo(value, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            results.Succeeded.ShouldBe(expected);
+        }
+
+
         #region ARRANGE
         public Double_IsGreaterThanOrEqualTo_Tests()
         {

--- a/tests/Valit.Tests/Double/Double_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsGreaterThan_Tests.cs
@@ -185,6 +185,23 @@ namespace Valit.Tests.Double
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999d, 0.000001d, true)]
+        [InlineData(9.999d, 0.01d, false)]
+        [InlineData(10d, double.Epsilon, false)]
+        [InlineData(10.0001d, 0.01d, false)]
+        [InlineData(10.0001d, 0.000001d, false)]
+        public void Double_IsGreaterThan_Returns_Proper_Results_For_GivenEpsilon_Value(double b, double epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsGreaterThan(b, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Double_IsGreaterThan_Tests()
         {
@@ -196,6 +213,7 @@ namespace Valit.Tests.Double
         class Model
         {
             public double Value => 10;
+            public double Epsilon => double.Epsilon;
             public double NaN => double.NaN;
             public double? NullableValue => 10;
             public double? NullValue => null;

--- a/tests/Valit.Tests/Double/Double_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsGreaterThan_Tests.cs
@@ -191,7 +191,7 @@ namespace Valit.Tests.Double
         [InlineData(10d, double.Epsilon, false)]
         [InlineData(10.0001d, 0.01d, false)]
         [InlineData(10.0001d, 0.000001d, false)]
-        public void Double_IsGreaterThan_Returns_Proper_Results_For_GivenEpsilon_Value(double b, double epsilon, bool expected)
+        public void Double_IsGreaterThan_Returns_Proper_Results_For_Given_Epsilon_Value(double b, double epsilon, bool expected)
         {
             IValitResult result = ValitRules<Model>
                                     .Create()

--- a/tests/Valit.Tests/Double/Double_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsLessThanOrEqualTo_Tests.cs
@@ -186,6 +186,23 @@ namespace Valit.Tests.Double
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999d, 0.000001d, false)]
+        [InlineData(9.999d, 0.01d, false)]
+        [InlineData(10d, double.Epsilon, false)]
+        [InlineData(10.0001d, 0.01d, false)]
+        [InlineData(10.0001d, 0.000001d, true)]
+        public void Double_IsLessThanOrEqual_Returns_Proper_Results_For_GivenEpsilon_Value(double b, double epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsLessThan(b, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Double_IsLessThanOrEqualTo_Tests()
         {

--- a/tests/Valit.Tests/Double/Double_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsLessThanOrEqualTo_Tests.cs
@@ -192,7 +192,7 @@ namespace Valit.Tests.Double
         [InlineData(10d, double.Epsilon, false)]
         [InlineData(10.0001d, 0.01d, false)]
         [InlineData(10.0001d, 0.000001d, true)]
-        public void Double_IsLessThanOrEqual_Returns_Proper_Results_For_GivenEpsilon_Value(double b, double epsilon, bool expected)
+        public void Double_IsLessThanOrEqual_Returns_Proper_Results_For_Given_Epsilon_Value(double b, double epsilon, bool expected)
         {
             IValitResult result = ValitRules<Model>
                                     .Create()

--- a/tests/Valit.Tests/Double/Double_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsLessThan_Tests.cs
@@ -193,7 +193,7 @@ namespace Valit.Tests.Double
         [InlineData(10d, double.Epsilon, false)]
         [InlineData(10.0001d, 0.01d, false)]
         [InlineData(10.0001d, 0.000001d, true)]
-        public void Double_IsLessThan_Returns_Proper_Results_For_GivenEpsilon_Value(double b, double epsilon, bool expected)
+        public void Double_IsLessThan_Returns_Proper_Results_For_Given_Epsilon_Value(double b, double epsilon, bool expected)
         {
             IValitResult result = ValitRules<Model>
                                     .Create()

--- a/tests/Valit.Tests/Double/Double_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsLessThan_Tests.cs
@@ -187,6 +187,23 @@ namespace Valit.Tests.Double
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999d, 0.000001d, false)]
+        [InlineData(9.999d, 0.01d, false)]
+        [InlineData(10d, double.Epsilon, false)]
+        [InlineData(10.0001d, 0.01d, false)]
+        [InlineData(10.0001d, 0.000001d, true)]
+        public void Double_IsLessThan_Returns_Proper_Results_For_GivenEpsilon_Value(double b, double epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsLessThan(b, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Double_IsLessThan_Tests()
         {

--- a/tests/Valit.Tests/Double/Double_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsNegative_Tests.cs
@@ -148,6 +148,21 @@ namespace Valit.Tests.Double
             result.Succeeded.ShouldBeFalse();
         }
 
+        [Theory]
+        [InlineData(0d, double.Epsilon, false)]
+        [InlineData(-0.000001d, 0.001d, true)]
+        [InlineData(-0.000001d, 0d, true)]
+        public void Double_IsNegative_Return_Proper_Results_For_Given_Epsilon_Value(double value, double epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => value, _ => _.IsNegative(epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Double_IsNegative_Tests()
         {

--- a/tests/Valit.Tests/Double/Double_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsNonZero_Tests.cs
@@ -96,6 +96,21 @@ namespace Valit.Tests.Double
             result.Succeeded.ShouldBeFalse();
         }
 
+        [Theory]
+        [InlineData(0d, double.Epsilon, false)]
+        [InlineData(0.000001d, 0.001d, true)]
+        [InlineData(0.000001d, 0d, true)]
+        public void Double_IsNonZero_Return_Proper_Results_For_Given_Epsilon_Value(double value, double epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => value, _ => _.IsNonZero(epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Double_IsNonZero_Tests()
         {

--- a/tests/Valit.Tests/Double/Double_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/Double/Double_IsPositive_Tests.cs
@@ -148,6 +148,22 @@ namespace Valit.Tests.Double
             result.Succeeded.ShouldBeFalse();
         }
 
+        [Theory]
+        [InlineData(0d, double.Epsilon, false)]
+        [InlineData(0.000001d, 0.001d, true)]
+        [InlineData(0.000001d, 0d, true)]
+        [InlineData(-0.000001d, 0.01d, false)]
+        public void Double_IsPositive_Return_Proper_Results_For_Given_Epsilon_Value(double value, double epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => value, _ => _.IsPositive(epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Double_IsPositive_Tests()
         {

--- a/tests/Valit.Tests/Extensions/DoubleExtensions_IsNearlyEqual_Tests.cs
+++ b/tests/Valit.Tests/Extensions/DoubleExtensions_IsNearlyEqual_Tests.cs
@@ -1,0 +1,174 @@
+using Shouldly;
+using Valit.Extensions;
+using Xunit;
+
+namespace Valit.Tests.Extensions
+{
+    public class DoubleExtensions_IsNearlyEqual_Tests
+    {
+        private const double DefinedEpsilon = 0.00001f;
+
+        [Theory(DisplayName = "Regular large numbers")]
+        [InlineData(1000000d, 1000001d, true)]
+        [InlineData(1000001d, 1000000d, true)]
+        [InlineData(10000d, 10001d, false)]
+        [InlineData(10001d, 10000d, false)]
+        public void Double_IsEqual_Returns_Proper_Result_For_BigNumbers(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Negative large numbers")]
+        [InlineData(-1000000d, -1000001d, true)]
+        [InlineData(-1000001d, -1000000d, true)]
+        [InlineData(-10000d, -10001d, false)]
+        [InlineData(-10001d, -10000d, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Negative_BigNumbers(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Numbers around 1")]
+        [InlineData(1.0000001d, 1.0000002d, true)]
+        [InlineData(1.0000002d, 1.0000001d, true)]
+        [InlineData(1.0002d, 1.0001d, false)]
+        [InlineData(1.0001d, 1.0002d, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Numbers_Around_1(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Numbers around -1")]
+        [InlineData(-1.000001d, -1.000002d, true)]
+        [InlineData(-1.000002d, -1.000001d, true)]
+        [InlineData(-1.0001d, -1.0002d, false)]
+        [InlineData(-1.0002d, -1.0001d, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Numbers_Around_Minus1(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Numbers between 1 and 0")]
+        [InlineData(0.000000001000001d, 0.000000001000002d, true)]
+        [InlineData(0.000000001000002d, 0.000000001000001d, true)]
+        [InlineData(0.000000000001002d, 0.000000000001001d, false)]
+        [InlineData(0.000000000001001d, 0.000000000001002d, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Numbers_Between_1_and_0(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Numbers between -1 and 0")]
+        [InlineData(-0.000000001000001d, -0.000000001000002d, true)]
+        [InlineData(-0.000000001000002d, -0.000000001000001d, true)]
+        [InlineData(-0.000000000001002d, -0.000000000001001d, false)]
+        [InlineData(-0.000000000001001d, -0.000000000001002d, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Numbers_Between_Minus1_and_0(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Small differences away from zero")]
+        [InlineData(0.3d, 0.30000003d, true)]
+        [InlineData(-0.3d, -0.30000003d, true)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Small_Differences_Away_From_Zero(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons involving zero")]
+        [InlineData(0.0d, 0.0d, DefinedEpsilon, true)]
+        [InlineData(0.0d, -0.0d, DefinedEpsilon, true)]
+        [InlineData(-0.0d, -0.0d, DefinedEpsilon, true)]
+        [InlineData(0.00000001d, 0.0d, DefinedEpsilon, false)]
+        [InlineData(0.0d, 0.00000001d, DefinedEpsilon, false)]
+        [InlineData(-0.00000001d, 0.0d, DefinedEpsilon, false)]
+        [InlineData(0.0d, -0.00000001d, DefinedEpsilon, false)]
+        [InlineData(0.0d, 1e-310d, 0.01d, true)]
+        [InlineData(1e-310d, 0.0d, 0.01d, true)]
+        [InlineData(1e-310d, 0.0d, 0.000001d, false)]
+        [InlineData(0.0d, 1e-310d, 0.000001d, false)]
+        [InlineData(0.0d, -1e-310d, 0.1d, true)]
+        [InlineData(-1e-310d, 0.0d, 0.1d, true)]
+        [InlineData(-1e-310d, 0.0d, 0.00000001d, false)]
+        [InlineData(0.0d, -1e-310d, 0.00000001d, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Zero(double a, double b, double epsilon, bool expected)
+        {
+            a.IsEqual(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons involving extreme values (overflow potential)")]
+        [InlineData(double.MaxValue, double.MaxValue, true)]
+        [InlineData(double.MaxValue, -double.MaxValue, false)]
+        [InlineData(-double.MaxValue, double.MaxValue, false)]
+        [InlineData(double.MaxValue, double.MaxValue / 2, false)]
+        [InlineData(double.MaxValue, -double.MaxValue / 2, false)]
+        [InlineData(-double.MaxValue, double.MaxValue / 2, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Extreme_Values(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons involving infinities")]
+        [InlineData(double.PositiveInfinity, double.PositiveInfinity, true)]
+        [InlineData(double.NegativeInfinity, double.NegativeInfinity, true)]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, false)]
+        [InlineData(double.PositiveInfinity, double.MaxValue, false)]
+        [InlineData(double.NegativeInfinity, -double.MaxValue, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Infinities(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons involving NaN values")]
+        [InlineData(double.NaN, double.NaN, false)]
+        [InlineData(double.NaN, 0.0d, false)]
+        [InlineData(-0.0d, double.NaN, false)]
+        [InlineData(double.NaN, -0.0d, false)]
+        [InlineData(0.0d, double.NaN, false)]
+        [InlineData(double.NaN, double.PositiveInfinity, false)]
+        [InlineData(double.PositiveInfinity, double.NaN, false)]
+        [InlineData(double.NaN, double.NegativeInfinity, false)]
+        [InlineData(double.NegativeInfinity, double.NaN, false)]
+        [InlineData(double.NaN, double.MaxValue, false)]
+        [InlineData(double.MaxValue, double.NaN, false)]
+        [InlineData(double.NaN, -double.MaxValue, false)]
+        [InlineData(-double.MaxValue, double.NaN, false)]
+        [InlineData(double.NaN, double.Epsilon, false)]
+        [InlineData(double.Epsilon, double.NaN, false)]
+        [InlineData(double.NaN, -double.Epsilon, false)]
+        [InlineData(-double.Epsilon, double.NaN, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_NaN_Values(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons of numbers on opposite sides of 0")]
+        [InlineData(1.000000001d, -1.0d, false)]
+        [InlineData(-1.0d, 1.000000001d, false)]
+        [InlineData(-1.000000001d, 1.0d, false)]
+        [InlineData(1.0d, -1.000000001d, false)]
+        [InlineData(10 * double.Epsilon, 10 * -double.Epsilon, true)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Number_On_Opposite_Sides_Of_Zero(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons of numbers very close to zero")]
+        [InlineData(double.Epsilon, double.Epsilon, true)]
+        [InlineData(double.Epsilon, -double.Epsilon, true)]
+        [InlineData(-double.Epsilon, double.Epsilon, true)]
+        [InlineData(double.Epsilon, 0, true)]
+        [InlineData(0, double.Epsilon, true)]
+        [InlineData(-double.Epsilon, 0, true)]
+        [InlineData(0, -double.Epsilon, true)]
+        [InlineData(0.000000001d, -double.Epsilon, false)]
+        [InlineData(0.000000001d, double.Epsilon, false)]
+        [InlineData(double.Epsilon, 0.000000001d, false)]
+        [InlineData(-double.Epsilon, 0.000000001d, false)]
+        public void Double_IsEqual_Returns_Proper_Results_For_Number_Very_Close_To_Zero(double a, double b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+    }
+}

--- a/tests/Valit.Tests/Extensions/DoubleExtensions_Tests.cs
+++ b/tests/Valit.Tests/Extensions/DoubleExtensions_Tests.cs
@@ -12,7 +12,7 @@ namespace Valit.Tests.Extensions
         [InlineData(0d, double.Epsilon, 0d, false)]
         [InlineData(.1d, .11d, 0d, false)]
         [InlineData(.01d, .011d, .1d, true)]
-        public void IsEqualTo_Returns_Proper_Results(double a, double b, double epsilon, bool expected)
+        public void IsEqual_Returns_Proper_Results(double a, double b, double epsilon, bool expected)
         {
             a.IsEqual(b, epsilon).ShouldBe(expected);
         }

--- a/tests/Valit.Tests/Extensions/DoubleExtensions_Tests.cs
+++ b/tests/Valit.Tests/Extensions/DoubleExtensions_Tests.cs
@@ -1,0 +1,76 @@
+using Shouldly;
+using Valit.Extensions;
+using Xunit;
+
+namespace Valit.Tests.Extensions
+{
+    public class DoubleExtensions_Tests
+    {
+        [Theory]
+        [InlineData(0d, 0d, 0d, true)]
+        [InlineData(0d, 0d, double.Epsilon, true)]
+        [InlineData(0d, double.Epsilon, 0d, false)]
+        [InlineData(.1d, .11d, 0d, false)]
+        [InlineData(.01d, .011d, .1d, true)]
+        public void IsEqualTo_Returns_Proper_Results(double a, double b, double epsilon, bool expected)
+        {
+            a.IsEqual(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0d, 0d, 0d, false)]
+        [InlineData(0d, 0d, double.Epsilon, false)]
+        [InlineData(0d, .1d, 0d, true)]
+        [InlineData(0d, .1d, double.Epsilon, true)]
+        [InlineData(.01d, .011d, .1d, false)]
+        public void IsNotEqual_Returns_Proper_Results(double a, double b, double epsilon, bool expected)
+        {
+            a.IsNotEqual(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0d, 0d, 0d, false)]
+        [InlineData(0d, 0d, double.Epsilon, false)]
+        [InlineData(.1d, 0.11d, 0d, false)]
+        [InlineData(.1d, 0.11d, double.Epsilon, false)]
+        [InlineData(.11d, 0.1d, 0d, true)]
+        [InlineData(.11d, 0.1d, double.Epsilon, true)]
+        public void IsGreaterThan_Returns_Proper_Results(double a, double b, double epsilon, bool expected)
+        {
+            a.IsGreaterThan(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0d, 0d, 0d, true)]
+        [InlineData(0d, 0d, double.Epsilon, true)]
+        [InlineData(.1d, 0d, 0d, true)]
+        [InlineData(.1d, .100001d, .01d, true)]
+        [InlineData(-.1d, 0d, 0d, false)]
+        public void IsGreaterOrEqualThan_Returns_Proper_Results(double a, double b, double epsilon, bool expected)
+        {
+            a.IsGreaterOrEqualThan(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0d, 0d, 0d, false)]
+        [InlineData(0d, 0d, double.Epsilon, false)]
+        [InlineData(.1d, .2d, 0d, true)]
+        [InlineData(.1d, .2d, double.Epsilon, true)]
+        [InlineData(-.01d, 0d, 0d, true)]
+        public void IsLessThan_Returns_Proper_Results(double a, double b, double epsilon, bool expected)
+        {
+            a.IsLessThan(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0d, 0d, 0d, true)]
+        [InlineData(0d, 0d, double.Epsilon, true)]
+        [InlineData(.1d, .11d, 0d, true)]
+        [InlineData(.1d, .11d, double.Epsilon, true)]
+        [InlineData(-.01d, 0d, 0d, true)]
+        public void IsLessOrEqualThan_Returns_Proper_Results(double a, double b, double epsilon, bool expected)
+        {
+            a.IsLessOrEqualThan(b, epsilon).ShouldBe(expected);
+        }
+    }
+}

--- a/tests/Valit.Tests/Extensions/DoubleExtensions_Tests.cs
+++ b/tests/Valit.Tests/Extensions/DoubleExtensions_Tests.cs
@@ -9,6 +9,7 @@ namespace Valit.Tests.Extensions
         [Theory]
         [InlineData(0d, 0d, 0d, true)]
         [InlineData(0d, 0d, double.Epsilon, true)]
+        [InlineData(0d, 0d, double.NaN, true)]
         [InlineData(0d, double.Epsilon, 0d, false)]
         [InlineData(.1d, .11d, 0d, false)]
         [InlineData(.01d, .011d, .1d, true)]

--- a/tests/Valit.Tests/Extensions/FloatExtensions_IsNearlyEqual_Tests.cs
+++ b/tests/Valit.Tests/Extensions/FloatExtensions_IsNearlyEqual_Tests.cs
@@ -1,0 +1,175 @@
+using Shouldly;
+using Valit.Extensions;
+using Xunit;
+
+namespace Valit.Tests.Extensions
+{
+    public class FloatExtensions_IsNearlyEqual_Tests
+    {
+        private const float DefinedEpsilon = 0.00001f;
+
+        [Theory(DisplayName = "Regular large numbers")]
+        [InlineData(1000000f, 1000001f, true)]
+        [InlineData(1000001f, 1000000f, true)]
+        [InlineData(10000f, 10001f, false)]
+        [InlineData(10001f, 10000f, false)]
+        public void Float_IsEqual_Returns_Proper_Result_For_BigNumbers(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Negative large numbers")]
+        [InlineData(-1000000f, -1000001f, true)]
+        [InlineData(-1000001f, -1000000f, true)]
+        [InlineData(-10000f, -10001f, false)]
+        [InlineData(-10001f, -10000f, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Negative_BigNumbers(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Numbers around 1")]
+        [InlineData(1.0000001f, 1.0000002f, true)]
+        [InlineData(1.0000002f, 1.0000001f, true)]
+        [InlineData(1.0002f, 1.0001f, false)]
+        [InlineData(1.0001f, 1.0002f, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Numbers_Around_1(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Numbers around -1")]
+        [InlineData(-1.000001f, -1.000002f, true)]
+        [InlineData(-1.000002f, -1.000001f, true)]
+        [InlineData(-1.0001f, -1.0002f, false)]
+        [InlineData(-1.0002f, -1.0001f, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Numbers_Around_Minus1(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Numbers between 1 and 0")]
+        [InlineData(0.000000001000001f, 0.000000001000002f, true)]
+        [InlineData(0.000000001000002f, 0.000000001000001f, true)]
+        [InlineData(0.000000000001002f, 0.000000000001001f, false)]
+        [InlineData(0.000000000001001f, 0.000000000001002f, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Numbers_Between_1_and_0(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Numbers between -1 and 0")]
+        [InlineData(-0.000000001000001f, -0.000000001000002f, true)]
+        [InlineData(-0.000000001000002f, -0.000000001000001f, true)]
+        [InlineData(-0.000000000001002f, -0.000000000001001f, false)]
+        [InlineData(-0.000000000001001f, -0.000000000001002f, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Numbers_Between_Minus1_and_0(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Small differences away from zero")]
+        [InlineData(0.3f, 0.30000003f, true)]
+        [InlineData(-0.3f, -0.30000003f, true)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Small_Differences_Away_From_Zero(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons involving zero")]
+        [InlineData(0.0f, 0.0f, DefinedEpsilon, true)]
+        [InlineData(0.0f, -0.0f, DefinedEpsilon, true)]
+        [InlineData(-0.0f, -0.0f, DefinedEpsilon, true)]
+        [InlineData(0.00000001f, 0.0f, DefinedEpsilon, false)]
+        [InlineData(0.0f, 0.00000001f, DefinedEpsilon, false)]
+        [InlineData(-0.00000001f, 0.0f, DefinedEpsilon, false)]
+        [InlineData(0.0f, -0.00000001f, DefinedEpsilon, false)]
+        [InlineData(0.0f, 1e-40f, 0.01f, true)]
+        [InlineData(1e-40f, 0.0f, 0.01f, true)]
+        [InlineData(1e-40f, 0.0f, 0.000001f, false)]
+        [InlineData(0.0f, 1e-40f, 0.000001f, false)]
+        [InlineData(0.0f, -1e-40f, 0.1f, true)]
+        [InlineData(-1e-40f, 0.0f, 0.1f, true)]
+        [InlineData(-1e-40f, 0.0f, 0.00000001f, false)]
+        [InlineData(0.0f, -1e-40f, 0.00000001f, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Zero(float a, float b, float epsilon, bool expected)
+        {
+            a.IsEqual(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons involving extreme values (overflow potential)")]
+        [InlineData(float.MaxValue, float.MaxValue, true)]
+        [InlineData(float.MaxValue, -float.MaxValue, false)]
+        [InlineData(-float.MaxValue, float.MaxValue, false)]
+        [InlineData(float.MaxValue, float.MaxValue / 2, false)]
+        [InlineData(float.MaxValue, -float.MaxValue / 2, false)]
+        [InlineData(-float.MaxValue, float.MaxValue / 2, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Extreme_Values(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons involving infinities")]
+        [InlineData(float.PositiveInfinity, float.PositiveInfinity, true)]
+        [InlineData(float.NegativeInfinity, float.NegativeInfinity, true)]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, false)]
+        [InlineData(float.PositiveInfinity, float.MaxValue, false)]
+        [InlineData(float.NegativeInfinity, -float.MaxValue, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Infinities(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons involving NaN values")]
+        [InlineData(float.NaN, float.NaN, false)]
+        [InlineData(float.NaN, 0.0f, false)]
+        [InlineData(-0.0f, float.NaN, false)]
+        [InlineData(float.NaN, -0.0f, false)]
+        [InlineData(0.0f, float.NaN, false)]
+        [InlineData(float.NaN, float.PositiveInfinity, false)]
+        [InlineData(float.PositiveInfinity, float.NaN, false)]
+        [InlineData(float.NaN, float.NegativeInfinity, false)]
+        [InlineData(float.NegativeInfinity, float.NaN, false)]
+        [InlineData(float.NaN, float.MaxValue, false)]
+        [InlineData(float.MaxValue, float.NaN, false)]
+        [InlineData(float.NaN, -float.MaxValue, false)]
+        [InlineData(-float.MaxValue, float.NaN, false)]
+        [InlineData(float.NaN, float.Epsilon, false)]
+        [InlineData(float.Epsilon, float.NaN, false)]
+        [InlineData(float.NaN, -float.Epsilon, false)]
+        [InlineData(-float.Epsilon, float.NaN, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_NaN_Values(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons of numbers on opposite sides of 0")]
+        [InlineData(1.000000001f, -1.0f, false)]
+        [InlineData(-1.0f, 1.000000001f, false)]
+        [InlineData(-1.000000001f, 1.0f, false)]
+        [InlineData(1.0f, -1.000000001f, false)]
+        [InlineData(10 * float.Epsilon, 10 * -float.Epsilon, true)]
+        [InlineData(10000 * float.Epsilon, 10000 * -float.Epsilon, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Number_On_Opposite_Sides_Of_Zero(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+
+        [Theory(DisplayName = "Comparisons of numbers very close to zero")]
+        [InlineData(float.Epsilon, float.Epsilon, true)]
+        [InlineData(float.Epsilon, -float.Epsilon, true)]
+        [InlineData(-float.Epsilon, float.Epsilon, true)]
+        [InlineData(float.Epsilon, 0, true)]
+        [InlineData(0, float.Epsilon, true)]
+        [InlineData(-float.Epsilon, 0, true)]
+        [InlineData(0, -float.Epsilon, true)]
+        [InlineData(0.000000001f, -float.Epsilon, false)]
+        [InlineData(0.000000001f, float.Epsilon, false)]
+        [InlineData(float.Epsilon, 0.000000001f, false)]
+        [InlineData(-float.Epsilon, 0.000000001f, false)]
+        public void Float_IsEqual_Returns_Proper_Results_For_Number_Very_Close_To_Zero(float a, float b, bool expected)
+        {
+            a.IsEqual(b, DefinedEpsilon).ShouldBe(expected);
+        }
+    }
+}

--- a/tests/Valit.Tests/Extensions/FloatExtensions_Tests.cs
+++ b/tests/Valit.Tests/Extensions/FloatExtensions_Tests.cs
@@ -9,6 +9,7 @@ namespace Valit.Tests.Extensions
         [Theory]
         [InlineData(0f, 0f, 0f, true)]
         [InlineData(0f, 0f, float.Epsilon, true)]
+        [InlineData(0f, 0f, float.NaN, true)]
         [InlineData(0f, float.Epsilon, 0f, false)]
         [InlineData(.1f, .11f, 0f, false)]
         [InlineData(.01f, .011f, .1f, true)]

--- a/tests/Valit.Tests/Extensions/FloatExtensions_Tests.cs
+++ b/tests/Valit.Tests/Extensions/FloatExtensions_Tests.cs
@@ -1,0 +1,76 @@
+using Shouldly;
+using Valit.Extensions;
+using Xunit;
+
+namespace Valit.Tests.Extensions
+{
+    public class FloatExtensions_Tests
+    {
+        [Theory]
+        [InlineData(0f, 0f, 0f, true)]
+        [InlineData(0f, 0f, float.Epsilon, true)]
+        [InlineData(0f, float.Epsilon, 0f, false)]
+        [InlineData(.1f, .11f, 0f, false)]
+        [InlineData(.01f, .011f, .1f, true)]
+        public void IsEqual_Returns_Proper_Results(float a, float b, float epsilon, bool expected)
+        {
+            a.IsEqual(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0f, 0f, 0f, false)]
+        [InlineData(0f, 0f, float.Epsilon, false)]
+        [InlineData(0f, .1f, 0f, true)]
+        [InlineData(0f, .1f, float.Epsilon, true)]
+        [InlineData(.01f, .011f, .1f, false)]
+        public void IsNotEqual_Returns_Proper_Results(float a, float b, float epsilon, bool expected)
+        {
+            a.IsNotEqual(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0f, 0f, 0f, false)]
+        [InlineData(0f, 0f, float.Epsilon, false)]
+        [InlineData(.1f, 0.11f, 0f, false)]
+        [InlineData(.1f, 0.11f, float.Epsilon, false)]
+        [InlineData(.11f, 0.1f, 0f, true)]
+        [InlineData(.11f, 0.1f, float.Epsilon, true)]
+        public void IsGreaterThan_Returns_Proper_Results(float a, float b, float epsilon, bool expected)
+        {
+            a.IsGreaterThan(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0f, 0f, 0f, true)]
+        [InlineData(0f, 0f, float.Epsilon, true)]
+        [InlineData(.1f, 0f, 0f, true)]
+        [InlineData(.1f, .100001f, .01f, true)]
+        [InlineData(-.1f, 0f, 0f, false)]
+        public void IsGreaterOrEqualThan_Returns_Proper_Results(float a, float b, float epsilon, bool expected)
+        {
+            a.IsGreaterOrEqualThan(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0f, 0f, 0f, false)]
+        [InlineData(0f, 0f, float.Epsilon, false)]
+        [InlineData(.1f, .2f, 0f, true)]
+        [InlineData(.1f, .2f, float.Epsilon, true)]
+        [InlineData(-.01f, 0f, 0f, true)]
+        public void IsLessThan_Returns_Proper_Results(float a, float b, float epsilon, bool expected)
+        {
+            a.IsLessThan(b, epsilon).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0f, 0f, 0f, true)]
+        [InlineData(0f, 0f, float.Epsilon, true)]
+        [InlineData(.1f, .11f, 0f, true)]
+        [InlineData(.1f, .11f, float.Epsilon, true)]
+        [InlineData(-.01f, 0f, 0f, true)]
+        public void IsLessOrEqualThan_Returns_Proper_Results(float a, float b, float epsilon, bool expected)
+        {
+            a.IsLessOrEqualThan(b, epsilon).ShouldBe(expected);
+        }
+    }
+}

--- a/tests/Valit.Tests/Float/Float_IsEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsEqualTo_Tests.cs
@@ -187,6 +187,23 @@ namespace Valit.Tests.Float
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999f, 0.000001f, false)]
+        [InlineData(9.999f, 0.01f, true)]
+        [InlineData(10f, float.Epsilon, true)]
+        [InlineData(10.0001f, 0.01f, true)]
+        [InlineData(10.0001f, 0.000001f, false)]
+        public void Float_IsEqualTo_Returns_Proper_Results_For_Given_Epsilon_Value(float value, float epsilon, bool expected)
+        {
+            IValitResult results = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsEqualTo(value, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            results.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Float_IsEqualTo_Tests()
         {

--- a/tests/Valit.Tests/Float/Float_IsGreaterThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsGreaterThanOrEqualTo_Tests.cs
@@ -186,6 +186,23 @@ namespace Valit.Tests.Float
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999f, 0.000001f, true)]
+        [InlineData(9.999f, 0.01f, true)]
+        [InlineData(10f, float.Epsilon, true)]
+        [InlineData(10.0001f, 0.01f, true)]
+        [InlineData(10.0001f, 0.000001f, false)]
+        public void Float_IsGreaterThanOrEqual_Returns_Proper_Results_For_Given_Epsilon_Value(float value, float epsilon, bool expected)
+        {
+            IValitResult results = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsGreaterThanOrEqualTo(value, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            results.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Float_IsGreaterThanOrEqualTo_Tests()
         {

--- a/tests/Valit.Tests/Float/Float_IsGreaterThan_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsGreaterThan_Tests.cs
@@ -185,6 +185,23 @@ namespace Valit.Tests.Float
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999f, 0.000001f, true)]
+        [InlineData(9.999f, 0.01f, false)]
+        [InlineData(10f, float.Epsilon, false)]
+        [InlineData(10.0001f, 0.01f, false)]
+        [InlineData(10.0001f, 0.000001f, false)]
+        public void Float_IsGreaterThan_Returns_Proper_Results_For_Given_Epsilon_Value(float b, float epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsGreaterThan(b, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Float_IsGreaterThan_Tests()
         {

--- a/tests/Valit.Tests/Float/Float_IsLessThanOrEqualTo_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsLessThanOrEqualTo_Tests.cs
@@ -186,6 +186,23 @@ namespace Valit.Tests.Float
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999f, 0.000001f, false)]
+        [InlineData(9.999f, 0.01f, false)]
+        [InlineData(10f, float.Epsilon, false)]
+        [InlineData(10.0001f, 0.01f, false)]
+        [InlineData(10.0001f, 0.000001f, true)]
+        public void Float_IsLessThanOrEqual_Returns_Proper_Results_For_Given_Epsilon_Value(float b, float epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsLessThan(b, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Float_IsLessThanOrEqualTo_Tests()
         {

--- a/tests/Valit.Tests/Float/Float_IsLessThan_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsLessThan_Tests.cs
@@ -187,6 +187,23 @@ namespace Valit.Tests.Float
             result.Succeeded.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData(9.999f, 0.000001f, false)]
+        [InlineData(9.999f, 0.01f, false)]
+        [InlineData(10f, float.Epsilon, false)]
+        [InlineData(10.0001f, 0.01f, false)]
+        [InlineData(10.0001f, 0.000001f, true)]
+        public void Float_IsLessThan_Returns_Proper_Results_For_Given_Epsilon_Value(float b, float epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => m.Value, _ => _.IsLessThan(b, epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Float_IsLessThan_Tests()
         {

--- a/tests/Valit.Tests/Float/Float_IsNegative_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsNegative_Tests.cs
@@ -148,6 +148,21 @@ namespace Valit.Tests.Float
             result.Succeeded.ShouldBeFalse();
         }
 
+        [Theory]
+        [InlineData(0f, float.Epsilon, false)]
+        [InlineData(-0.000001f, 0.001f, true)]
+        [InlineData(-0.000001f, 0f, true)]
+        public void Float_IsNegative_Return_Proper_Results_For_Given_Epsilon_Value(float value, float epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => value, _ => _.IsNegative(epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Float_IsNegative_Tests()
         {

--- a/tests/Valit.Tests/Float/Float_IsNonZero_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsNonZero_Tests.cs
@@ -96,6 +96,21 @@ namespace Valit.Tests.Float
             result.Succeeded.ShouldBeFalse();
         }
 
+        [Theory]
+        [InlineData(0f, float.Epsilon, false)]
+        [InlineData(0.000001f, 0.001f, true)]
+        [InlineData(0.000001f, 0f, true)]
+        public void Float_IsNonZero_Return_Proper_Results_For_Given_Epsilon_Value(float value, float epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => value, _ => _.IsNonZero(epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Float_IsNonZero_Tests()
         {

--- a/tests/Valit.Tests/Float/Float_IsPositive_Tests.cs
+++ b/tests/Valit.Tests/Float/Float_IsPositive_Tests.cs
@@ -148,6 +148,22 @@ namespace Valit.Tests.Float
             result.Succeeded.ShouldBeFalse();
         }
 
+        [Theory]
+        [InlineData(0f, float.Epsilon, false)]
+        [InlineData(0.000001f, 0.001f, true)]
+        [InlineData(0.000001f, 0f, true)]
+        [InlineData(-0.000001f, 0.01f, false)]
+        public void Float_IsPositive_Return_Proper_Results_For_Given_Epsilon_Value(float value, float epsilon, bool expected)
+        {
+            IValitResult result = ValitRules<Model>
+                                    .Create()
+                                    .Ensure(m => value, _ => _.IsPositive(epsilon))
+                                    .For(_model)
+                                    .Validate();
+
+            result.Succeeded.ShouldBe(expected);
+        }
+
         #region ARRANGE
         public Float_IsPositive_Tests()
         {


### PR DESCRIPTION
# Info
This Pull Request is related to issue no. [#32]

Mathematical algorithm taken from: https://floating-point-gui.de/errors/comparison/
However this solution is not perfect as this problem is not easy to solve. Check: [Comparing Floating Point Numbers, 2012 Edition](https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/)
# Changes:
1. Added extensions methods for Double and Float type:
- IsEqual
- IsNearlyEqual
- IsNotEqual
- IsGreaterThan
- IsGreaterOrEqualThan
- IsLessThan
- IsLessOrEqualThan

2. Adjusted valit rules for Double and Float comparison
